### PR TITLE
fix: pin eslint-plugin-jsx-a11y to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-config-airbnb": "^17.0.0",
     "eslint-import-resolver-node": "^0.3.2",
     "eslint-plugin-import": "2.12.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-jsx-a11y": "6.0.3",
     "eslint-plugin-react": "7.10.0",
     "greenkeeper-lockfile": "^1.15.1",
     "ink-docstrap": "^1.3.2",


### PR DESCRIPTION
fixes #95 