### PR TITLE
Translations respect provided locale

### DIFF
--- a/lib/ChallengeInstance.js
+++ b/lib/ChallengeInstance.js
@@ -1,12 +1,12 @@
 'use strict';
 
 class ChallengeInstance {
-  constructor(data, { translator }) {
+  constructor(data, { translator, locale }) {
     /**
      * Type of challenge
      * @type {string}
      */
-    this.type = translator.languageString(data.Type);
+    this.type = translator.languageString(data.Type, locale);
 
     /**
      * Minimum enemy level to fulfill challenge
@@ -30,14 +30,16 @@ class ChallengeInstance {
      * Required damage type
      * @type {String|undefined}
      */
-    this.damageType = data.DamageType ? translator.languageString(data.DamageType) : undefined;
+    this.damageType = data.DamageType
+      ? translator.languageString(data.DamageType, locale)
+      : undefined;
 
     /**
      * Target to fulfill challenge
      * @type {string}
      */
     this.target = data.VictimType && data.VictimType[0]
-      ? translator.languageString(data.VictimType[0])
+      ? translator.languageString(data.VictimType[0], locale)
       : data.Script._faction;
   }
 

--- a/lib/ConclaveChallenge.js
+++ b/lib/ConclaveChallenge.js
@@ -13,8 +13,11 @@ class ConclaveChallenge extends WorldstateObject {
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, timeDate }) {
+  constructor(data, {
+    mdConfig, translator, timeDate, locale,
+  }) {
     super(data, { timeDate });
 
     /**
@@ -37,7 +40,7 @@ class ConclaveChallenge extends WorldstateObject {
      * The challenge's description text
      * @type {string}
      */
-    this.description = translator.languageString(data.challengeTypeRefID);
+    this.description = translator.languageString(data.challengeTypeRefID, locale);
 
     /**
      * The time and date at which the challenge expires
@@ -55,13 +58,13 @@ class ConclaveChallenge extends WorldstateObject {
      * The PVP mode that the challenge must be completed in
      * @type {string}
      */
-    this.mode = translator.conclaveMode(data.PVPMode);
+    this.mode = translator.conclaveMode(data.PVPMode, locale);
 
     /**
      * The challenge's category (daily, weekly...)
      * @type {string}
      */
-    this.category = translator.conclaveCategory(data.Category);
+    this.category = translator.conclaveCategory(data.Category, locale);
 
     /**
      * ETA string (at time of object creation)

--- a/lib/DailyDeal.js
+++ b/lib/DailyDeal.js
@@ -10,8 +10,11 @@ class DailyDeal {
    * @param   {MarkdownSettings}  deps.mdConfig   The markdown settings
    * @param   {Translator}        deps.translator The string translator
    * @param   {TimeDateFunctions} deps.timeDate   The time and date functions
+   * @param   {string}            deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, timeDate }) {
+  constructor(data, {
+    mdConfig, translator, timeDate, locale,
+  }) {
     /**
      * The markdown settings
      * @type {MarkdownSettings}
@@ -32,7 +35,7 @@ class DailyDeal {
      * The item that is being offered in the sale
      * @type {string}
      */
-    this.item = translator.languageString(data.StoreItem);
+    this.item = translator.languageString(data.StoreItem, locale);
 
     /**
      * The date and time at which the deal will expire

--- a/lib/DarkSector.js
+++ b/lib/DarkSector.js
@@ -16,14 +16,15 @@ class DarkSector extends WorldstateObject {
    * @param   {function}           deps.Mission          The mission parser
    * @param   {function}           deps.DarkSectorBattle The dark sector battle parser
    * @param   {function}           deps.Reward           The reward parser
+   * @param   {string}             deps.locale     Locale to use for translations
    */
   constructor(data, {
-    mdConfig, translator, timeDate, Mission, DarkSectorBattle, Reward,
+    mdConfig, translator, timeDate, Mission, DarkSectorBattle, Reward, locale,
   }) {
     super(data, { timeDate });
 
     const deps = {
-      translator, Mission, DarkSectorBattle, mdConfig, Reward, timeDate,
+      translator, Mission, DarkSectorBattle, mdConfig, Reward, timeDate, locale,
     };
 
     /**
@@ -85,7 +86,7 @@ class DarkSector extends WorldstateObject {
      * The solar rail type
      * @type {string}
      */
-    this.railType = translator.languageString(data.DefenderInfo.RailType);
+    this.railType = translator.languageString(data.DefenderInfo.RailType, locale);
 
     /**
      * The MOTD set by the dark sector holder

--- a/lib/Event.js
+++ b/lib/Event.js
@@ -33,14 +33,15 @@ class Event extends WorldstateObject {
    * @param   {Translator}        deps.translator The string translator
    * @param   {TimeDateFunctions} deps.timeDate   The time and date functions
    * @param   {function}          deps.Reward     The Reward parser
+   * @param   {string}            deps.locale     Locale to use for translations
    */
   constructor(data, {
-    mdConfig, translator, timeDate, Reward,
+    mdConfig, translator, timeDate, Reward, locale,
   }) {
     super(data, { timeDate });
 
     const opts = {
-      translator, mdConfig, Reward, timeDate,
+      translator, mdConfig, Reward, timeDate, locale,
     };
 
     /**
@@ -92,39 +93,39 @@ class Event extends WorldstateObject {
      * The faction that the players must fight in the event
      * @type {string}
      */
-    this.faction = translator.faction(data.Faction);
+    this.faction = translator.faction(data.Faction, locale);
 
     /**
      * The description of the event
      * @type {string}
      */
-    this.description = translator.languageString(data.Desc);
+    this.description = translator.languageString(data.Desc, locale);
 
     /**
      * Tooltip for the event
      * @type {?string}
      */
-    this.tooltip = translator.languageString(data.ToolTip);
+    this.tooltip = translator.languageString(data.ToolTip, locale);
 
     /**
      * The node where the event takes place
      * @type {?string}
      */
-    this.node = translator.node(data.Node);
+    this.node = translator.node(data.Node, locale);
 
     /**
      * The other nodes where the event takes place
      * @type {string[]}
      */
     this.concurrentNodes = data.ConcurrentNodes
-      ? data.ConcurrentNodes.map(n => translator.node(n))
+      ? data.ConcurrentNodes.map(n => translator.node(n), locale)
       : [];
 
     /**
      * The victim node
      * @type {?string}
      */
-    this.victimNode = translator.node(data.VictimNode);
+    this.victimNode = translator.node(data.VictimNode, locale);
 
     /**
      * The score description
@@ -132,7 +133,7 @@ class Event extends WorldstateObject {
      */
     this.scoreLocTag = data.Fomorian
       ? 'Fomorian Assault Score'
-      : translator.languageString(data.ScoreLocTag);
+      : translator.languageString(data.ScoreLocTag, locale);
 
     /**
      * The event's rewards
@@ -157,7 +158,7 @@ class Event extends WorldstateObject {
       : undefined;
 
     if (data.JobAffiliationTag) {
-      this.affiliatedWith = translator.syndicate(data.JobAffiliationTag);
+      this.affiliatedWith = translator.syndicate(data.JobAffiliationTag, locale);
       if (data.Jobs) {
         this.jobs = (data.Jobs || []).map(j => new SyndicateJob(j, this.expiry, opts));
       }
@@ -175,9 +176,9 @@ class Event extends WorldstateObject {
         goal: data.InterimGoals[index],
         reward: reward ? new Reward(reward, opts) : undefined,
         message: {
-          sender: translator.languageString(msg.sender),
-          subject: translator.languageString(msg.subject),
-          message: translator.languageString(msg.message),
+          sender: translator.languageString(msg.sender, locale),
+          subject: translator.languageString(msg.subject, locale),
+          message: translator.languageString(msg.message, locale),
           senderIcon: msg.senderIcon,
           attachments: msg.attachments,
         },
@@ -194,7 +195,7 @@ class Event extends WorldstateObject {
     if (data.IsMultiProgress) {
       data.Types.forEach((type, index) => {
         this.progressSteps[index] = {
-          type: translator.languageString(type),
+          type: translator.languageString(type, locale),
           progressAmt: data.MultiProgress[index],
         };
       });

--- a/lib/Fissure.js
+++ b/lib/Fissure.js
@@ -12,8 +12,9 @@ class Fissure extends WorldstateObject {
    * @param   {Object}             deps            The dependencies object
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { translator, timeDate }) {
+  constructor(data, { translator, timeDate, locale }) {
     super(data, { timeDate });
 
     /**
@@ -28,31 +29,31 @@ class Fissure extends WorldstateObject {
      * The node where the fissure has appeared
      * @type {string}
      */
-    this.node = translator.node(data.Node);
+    this.node = translator.node(data.Node, locale);
 
     /**
      * The fissure mission type
      * @type {string}
      */
-    this.missionType = translator.missionType(data.MissionType);
+    this.missionType = translator.missionType(data.MissionType, locale);
 
     /**
      * The faction controlling the node where the fissure has appeared
      * @type {string}
      */
-    this.enemy = translator.nodeEnemy(data.Node);
+    this.enemy = translator.nodeEnemy(data.Node, locale);
 
     /**
      * The fissure's tier
      * @type {string}
      */
-    this.tier = translator.fissureModifier(data.Modifier);
+    this.tier = translator.fissureModifier(data.Modifier, locale);
 
     /**
      * The fissure's tier as a number
      * @type {number}
      */
-    this.tierNum = translator.fissureTier(data.Modifier);
+    this.tierNum = translator.fissureTier(data.Modifier, locale);
 
     /**
      * The date and time at which the fissure appeared

--- a/lib/FlashSale.js
+++ b/lib/FlashSale.js
@@ -10,8 +10,11 @@ class FlashSale {
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { translator, mdConfig, timeDate }) {
+  constructor(data, {
+    translator, mdConfig, timeDate, locale,
+  }) {
     /**
      * The markdown settings
      * @type {MarkdownSettings}
@@ -32,7 +35,7 @@ class FlashSale {
      * The item being offered in the flash sale
      * @type {string}
      */
-    this.item = translator.languageString(data.TypeName);
+    this.item = translator.languageString(data.TypeName, locale);
 
     /**
      * The date and time at which the sale will end

--- a/lib/GlobalUpgrade.js
+++ b/lib/GlobalUpgrade.js
@@ -10,8 +10,11 @@ class GlobalUpgrade {
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { translator, timeDate, mdConfig }) {
+  constructor(data, {
+    translator, timeDate, mdConfig, locale,
+  }) {
     /**
      * The time and date functions
      * @type {TimeDateFunctions}
@@ -44,19 +47,19 @@ class GlobalUpgrade {
      * The effect of the upgrade
      * @type {string}
      */
-    this.upgrade = translator.upgrade(data.UpgradeType);
+    this.upgrade = translator.upgrade(data.UpgradeType, locale);
 
     /**
      * The operation type
      * @type {string}
      */
-    this.operation = translator.operation(data.OperationType);
+    this.operation = translator.operation(data.OperationType, locale);
 
     /**
      * Symbol for operation
      * @type {string}
      */
-    this.operationSymbol = translator.operationSymbol(data.OperationType);
+    this.operationSymbol = translator.operationSymbol(data.OperationType, locale);
 
     /**
      * The operation value

--- a/lib/Invasion.js
+++ b/lib/Invasion.js
@@ -13,14 +13,15 @@ class Invasion extends WorldstateObject {
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
    * @param   {function}           deps.Reward     The Reward parser
+   * @param   {string}             deps.locale     Locale to use for translations
    */
   constructor(data, {
-    mdConfig, translator, timeDate, Reward,
+    mdConfig, translator, timeDate, Reward, locale,
   }) {
     super(data, { timeDate });
 
     const opts = {
-      mdConfig, translator, timeDate, Reward,
+      mdConfig, translator, timeDate, Reward, locale,
     };
 
     /**
@@ -43,13 +44,13 @@ class Invasion extends WorldstateObject {
      * The node where the invasion is taking place
      * @type {string}
      */
-    this.node = translator.node(data.Node);
+    this.node = translator.node(data.Node, locale);
 
     /**
      * The invasion's description
      * @type {string}
      */
-    this.desc = translator.languageString(data.LocTag);
+    this.desc = translator.languageString(data.LocTag, locale);
 
     /**
      * The attacker's reward
@@ -61,7 +62,7 @@ class Invasion extends WorldstateObject {
      * The attacking faction
      * @type {string}
      */
-    this.attackingFaction = translator.faction(data.DefenderMissionInfo.faction);
+    this.attackingFaction = translator.faction(data.DefenderMissionInfo.faction, locale);
 
     /**
      * The defender's reward
@@ -73,7 +74,7 @@ class Invasion extends WorldstateObject {
      * The defending faction
      * @type {string}
      */
-    this.defendingFaction = translator.faction(data.AttackerMissionInfo.faction);
+    this.defendingFaction = translator.faction(data.AttackerMissionInfo.faction, locale);
 
     /**
      * Whether this invasion is against the infestation

--- a/lib/Mission.js
+++ b/lib/Mission.js
@@ -10,9 +10,14 @@ class Mission {
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
    * @param   {function}           deps.Reward     The Reward parser
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, Reward }) {
-    const deps = { mdConfig, translator, Reward };
+  constructor(data, {
+    mdConfig, translator, Reward, locale,
+  }) {
+    const deps = {
+      mdConfig, translator, Reward, locale,
+    };
 
     /**
      * The markdown settings
@@ -26,25 +31,25 @@ class Mission {
      * The mission's description
      * @type {?string}
      */
-    this.description = translator.languageString(data.descText);
+    this.description = translator.languageString(data.descText, locale);
 
     /**
      * The node where the mission takes place
      * @type {string}
      */
-    this.node = translator.node(data.location);
+    this.node = translator.node(data.location, locale);
 
     /**
      * The mission's type
      * @type {string}
      */
-    this.type = translator.missionType(data.missionType);
+    this.type = translator.missionType(data.missionType, locale);
 
     /**
      * The factions that the players must fight in the mission
      * @type {string}
      */
-    this.faction = translator.faction(data.faction);
+    this.faction = translator.faction(data.faction, locale);
 
     /**
      * The mission's reward

--- a/lib/News.js
+++ b/lib/News.js
@@ -9,11 +9,12 @@ const streamReg = /(devstream|prime-time|warframeinternational)/i;
 /**
  * Represents a game news item
  * @extends {WorldstateObject}
+ * @typedef {WorldstateObject} News
  */
 class News extends WorldstateObject {
   /**
    * @param   {Object}             data            The news data
-   * @param   {Object}             deps            The dependencies object
+   * @param   {Dependency}         deps            The dependencies object
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
    */

--- a/lib/Nightwave.js
+++ b/lib/Nightwave.js
@@ -16,16 +16,17 @@ class Nightwave extends WorldstateObject {
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
    * @param   {function}           deps.Mission    The Mission parser
    * @param   {function}           deps.Reward     The Reward parser
+   * @param   {string}             deps.locale     Locale to use for translations
    */
   constructor(data, {
-    mdConfig, translator, timeDate, Mission, Reward,
+    mdConfig, translator, timeDate, Mission, Reward, locale,
   }) {
     super(data, { timeDate });
 
     this.id = `nightwave${new Date(this.expiry).getTime()}`;
 
     const deps = {
-      mdConfig, translator, timeDate, Mission, Reward,
+      mdConfig, translator, timeDate, Mission, Reward, locale,
     };
 
     /**
@@ -54,7 +55,7 @@ class Nightwave extends WorldstateObject {
      * Descriptor for affiliation
      * @type {string}
      */
-    this.tag = translator.languageString(data.AffiliationTag);
+    this.tag = translator.languageString(data.AffiliationTag, locale);
 
     /**
      * The current season's current phase. 0-indexed.

--- a/lib/NightwaveChallenge.js
+++ b/lib/NightwaveChallenge.js
@@ -12,14 +12,12 @@ class NightwaveChallenge extends WorldstateObject {
   /**
    * @param   {Object}             data            The alert data
    * @param   {Object}             deps            The dependencies object
-   * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
-   * @param   {function}           deps.Mission    The Mission parser
-   * @param   {function}           deps.Reward     The Reward parser
+   * @param   {string}             deps.locale     Locale to use for translations
    */
   constructor(data, {
-    translator, timeDate,
+    translator, timeDate, locale,
   }) {
     super(data, { timeDate });
 
@@ -39,13 +37,13 @@ class NightwaveChallenge extends WorldstateObject {
      * The descriptor for this challenge
      * @type {string}
      */
-    this.desc = translator.languageDesc(data.Challenge);
+    this.desc = translator.languageDesc(data.Challenge, locale);
 
     /**
      * The title for this challenge
      * @type {string}
      */
-    this.title = translator.languageString(data.Challenge);
+    this.title = translator.languageString(data.Challenge, locale);
 
     /**
      * Generated id from expiry, challenge string,

--- a/lib/PersistentEnemy.js
+++ b/lib/PersistentEnemy.js
@@ -11,8 +11,11 @@ class PersistentEnemy extends WorldstateObject {
    * @param   {Object}             deps            The dependencies object
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, timeDate }) {
+  constructor(data, {
+    mdConfig, translator, timeDate, locale,
+  }) {
     super(data, { timeDate });
 
     /**
@@ -27,13 +30,13 @@ class PersistentEnemy extends WorldstateObject {
      * The enemy's type
      * @type {string}
      */
-    this.agentType = translator.languageString(data.AgentType);
+    this.agentType = translator.languageString(data.AgentType, locale);
 
     /**
      * The location tag
      * @type {string}
      */
-    this.locationTag = translator.languageString(data.LocTag);
+    this.locationTag = translator.languageString(data.LocTag, locale);
 
     /**
      * The enemy's rank
@@ -57,7 +60,7 @@ class PersistentEnemy extends WorldstateObject {
      * The region where the enemy is located
      * @type {string}
      */
-    this.region = translator.region(data.Region);
+    this.region = translator.region(data.Region, locale);
 
     /**
      * The last time the enemy was discovered
@@ -69,7 +72,7 @@ class PersistentEnemy extends WorldstateObject {
      * The node at which the enemy was last discovered
      * @type {string}
      */
-    this.lastDiscoveredAt = translator.node(data.LastDiscoveredLocation);
+    this.lastDiscoveredAt = translator.node(data.LastDiscoveredLocation, locale);
 
     /**
      * Whether or not the enemy is currently available

--- a/lib/Reward.js
+++ b/lib/Reward.js
@@ -433,13 +433,14 @@ class Reward {
    * @param   {Object} data                 The mission data
    * @param   {Object}             deps            The dependencies object
    * @param   {Translator}         deps.translator The string translator
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { translator }) {
+  constructor(data, { translator, locale }) {
     /**
      * The items being rewarded
      * @type {Array.<string>}
      */
-    this.items = data.items ? data.items.map(i => translator.languageString(i)) : [];
+    this.items = data.items ? data.items.map(i => translator.languageString(i), locale) : [];
 
     /**
      * The counted items being rewarded
@@ -447,7 +448,7 @@ class Reward {
      */
     this.countedItems = data.countedItems ? data.countedItems.map(i => ({
       count: i.ItemCount,
-      type: translator.languageString(i.ItemType),
+      type: translator.languageString(i.ItemType, locale),
     })) : [];
 
     /**

--- a/lib/Simaris.js
+++ b/lib/Simaris.js
@@ -9,8 +9,9 @@ class Simaris {
    * @param   {Object}             deps            The dependencies object
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator }) {
+  constructor(data, { mdConfig, translator, locale }) {
     /**
      * The markdown settings
      * @type {MarkdownSettings}
@@ -23,7 +24,7 @@ class Simaris {
      * The sanctuary target
      * @type {string}
      */
-    this.target = translator.languageString(data.LastCompletedTargetType) || 'N/a';
+    this.target = translator.languageString(data.LastCompletedTargetType, locale) || 'N/A';
 
     /**
      * Whether or not the target is currently active

--- a/lib/Sortie.js
+++ b/lib/Sortie.js
@@ -15,14 +15,15 @@ class Sortie extends WorldstateObject {
    * @param   {TimeDateFunctions} deps.timeDate      The time and date functions
    * @param   {Object}            deps.sortieData    The data used to parse sorties
    * @param   {function}          deps.SortieVariant The sortie variant parser
+   * @param   {string}            deps.locale        Locale to use for translations
    */
   constructor(data, {
-    mdConfig, translator, timeDate, sortieData, SortieVariant,
+    mdConfig, translator, timeDate, sortieData, SortieVariant, locale,
   }) {
     super(data, { timeDate });
 
     const opts = {
-      mdConfig, translator, timeDate, sortieData, SortieVariant,
+      mdConfig, translator, timeDate, sortieData, SortieVariant, locale,
     };
 
     /**
@@ -57,7 +58,7 @@ class Sortie extends WorldstateObject {
      * The sortie's reward pool
      * @type {string}
      */
-    this.rewardPool = translator.languageString(data.Reward);
+    this.rewardPool = translator.languageString(data.Reward, locale);
 
     /**
      * The sortie's variants
@@ -69,13 +70,13 @@ class Sortie extends WorldstateObject {
      * The sortie's boss
      * @type {string}
      */
-    this.boss = data.Boss ? translator.sortieBoss(data.Boss) : this.variants[0].boss;
+    this.boss = data.Boss ? translator.sortieBoss(data.Boss, locale) : this.variants[0].boss;
 
     /**
      * The sortie's faction
      * @type {string}
      */
-    this.faction = data.Boss ? translator.sortieFaction(data.Boss) : 'Unknown';
+    this.faction = data.Boss ? translator.sortieFaction(data.Boss, locale) : 'Unknown';
 
     /**
      * Whether or not this is expired (at time of object creation)

--- a/lib/SortieVariant.js
+++ b/lib/SortieVariant.js
@@ -12,8 +12,11 @@ class SortieVariant {
    * @param   {MarkdownSettings}  deps.mdConfig      The markdown settings
    * @param   {Translator}        deps.translator    The string translator
    * @param   {Object}            deps.sortieData    The data used to parse sorties
+   * @param   {string}            deps.locale        Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, sortieData }) {
+  constructor(data, {
+    mdConfig, translator, sortieData, locale,
+  }) {
     /**
      * The markdown settings
      * @type {MarkdownSettings}
@@ -39,19 +42,19 @@ class SortieVariant {
        * The variant's mission type
        * @type {string}
        */
-      this.missionType = translator.missionType(data.missionType);
+      this.missionType = translator.missionType(data.missionType, locale);
 
       /**
        * The variant's modifier
        * @type {string}
        */
-      this.modifier = translator.sortieModifier(data.modifierType);
+      this.modifier = translator.sortieModifier(data.modifierType, locale);
 
       /**
        * The variant's modifier description
        * @type {string}
        */
-      this.modifierDescription = translator.sortieModDesc(data.modifierType);
+      this.modifierDescription = translator.sortieModDesc(data.modifierType, locale);
     } else {
       this.boss = sortieData.endStates[data.bossIndex].bossName;
       const region = sortieData.endStates[data.bossIndex].regions[data.regionIndex];
@@ -64,7 +67,7 @@ class SortieVariant {
      * The node where the variant takes place
      * @type {string}
      */
-    this.node = translator.node(data.node);
+    this.node = translator.node(data.node, locale);
   }
 
   /**

--- a/lib/SyndicateJob.js
+++ b/lib/SyndicateJob.js
@@ -104,8 +104,9 @@ class SyndicateJob extends WorldstateObject {
    * @param   {Date}               expiry          The syndicate job expiration
    * @param   {Object}             deps            The dependencies object
    * @param   {Translator}         deps.translator The string translator
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, expiry, { translator, timeDate }) {
+  constructor(data, expiry, { translator, timeDate, locale }) {
     super({ _id: { $oid: `${data.jobType.split('/').slice(-1)[0]}${expiry.getTime()}` } }, { timeDate });
 
     /**
@@ -122,7 +123,7 @@ class SyndicateJob extends WorldstateObject {
      * The type of job this is
      * @type {String}
      */
-    this.type = translator.languageString(data.jobType);
+    this.type = translator.languageString(data.jobType, locale);
 
     /**
      * Array of enemy levels

--- a/lib/SyndicateMission.js
+++ b/lib/SyndicateMission.js
@@ -14,11 +14,16 @@ class SyndicateMission extends WorldstateObject {
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, timeDate }) {
+  constructor(data, {
+    mdConfig, translator, timeDate, locale,
+  }) {
     super(data, { timeDate });
 
-    const deps = { mdConfig, translator, timeDate };
+    const deps = {
+      mdConfig, translator, timeDate, locale,
+    };
 
     /**
      * The markdown settings
@@ -60,13 +65,13 @@ class SyndicateMission extends WorldstateObject {
      * The syndicate that is offering the mission
      * @type {string}
      */
-    this.syndicate = translator.syndicate(data.Tag);
+    this.syndicate = translator.syndicate(data.Tag, locale);
 
     /**
      * The nodes on which the missions are taking place
      * @type {Array.<string>}
      */
-    this.nodes = data.Nodes.map(n => translator.node(n));
+    this.nodes = data.Nodes.map(n => translator.node(n), locale);
 
     /**
      * The jobs for this syndicate. Will normally be []

--- a/lib/VoidTrader.js
+++ b/lib/VoidTrader.js
@@ -13,8 +13,11 @@ class VoidTrader extends WorldstateObject {
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
    * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
+   * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data, { mdConfig, translator, timeDate }) {
+  constructor(data, {
+    mdConfig, translator, timeDate, locale,
+  }) {
     super(data, { timeDate });
 
     /**
@@ -55,14 +58,14 @@ class VoidTrader extends WorldstateObject {
      * The node at which the Void Trader appears
      * @type {string}
      */
-    this.location = translator.node(data.Node);
+    this.location = translator.node(data.Node, locale);
 
     /**
      * The trader's inventory
      * @type {Array}
      */
     this.inventory = data.Manifest ? data.Manifest.map(i => ({
-      item: translator.languageString(i.ItemType),
+      item: translator.languageString(i.ItemType, locale),
       ducats: i.PrimePrice,
       credits: i.RegularPrice,
     })) : [];

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -48,6 +48,21 @@ const Nightwave = require('./Nightwave');
  * @property {string} codeBlock    - String for denoting multi-line code blocks
  */
 
+/**
+ * Dependency Object
+ * @typedef {Object} Dependency
+ * @property   {MarkdownSettings}   mdConfig   The markdown settings
+ * @property   {Translator}         translator The string translator
+ * @property   {TimeDateFunctions}  timeDate   The time and date functions
+ * @property   {function}           Mission    The Mission parser
+ * @property   {function}           Reward     The Reward parser
+ * @property   {string}             locale     Locale to use for translations
+ */
+
+/**
+ * Default Dependency object
+ * @type {Dependency}
+ */
 const defaultDeps = {
   News,
   Event,
@@ -72,6 +87,7 @@ const defaultDeps = {
   translator,
   sortieData,
   mdConfig,
+  locale: 'en',
 };
 
 function parseArray(ParserClass, dataArray, deps, uniqueField) {
@@ -108,6 +124,12 @@ class WorldState {
       throw new TypeError('json needs to be a string');
     }
     const data = JSON.parse(json);
+
+    // eslint-disable-next-line no-param-reassign
+    deps = {
+      ...defaultDeps,
+      ...deps,
+    };
 
     /**
      * The date and time at which the World State was generated

--- a/lib/translation.js
+++ b/lib/translation.js
@@ -33,156 +33,159 @@ function splitResourceName(str) {
   return str.split(/([A-Z]?[^A-Z]*)/g).filter(item => item).join(' ');
 }
 
-function faction(key) {
-  if (key in data.factions) {
-    return data.factions[key].value;
+const i18n = (locale = 'en') => data[locale];
+
+function faction(key, dataOverride) {
+  if (key in i18n(dataOverride).factions) {
+    return i18n(dataOverride).factions[key].value;
   }
   return key;
 }
 
-function node(key) {
-  if (key in data.solNodes) {
-    return data.solNodes[key].value;
+function node(key, dataOverride) {
+  if (key in i18n(dataOverride).solNodes) {
+    return i18n(dataOverride).solNodes[key].value;
   } if (key) {
     return key.split('/').slice(-1)[0];
   }
   return key;
 }
 
-function nodeMissionType(key) {
-  if (key in data.solNodes) {
-    return data.solNodes[key].type;
+function nodeMissionType(key, dataOverride) {
+  if (key in i18n(dataOverride).solNodes) {
+    return i18n(dataOverride).solNodes[key].type;
   } if (key) {
     return key.split('/').slice(-1)[0];
   }
   return key;
 }
 
-function nodeEnemy(key) {
-  if (key in data.solNodes) {
-    return data.solNodes[key].enemy;
+function nodeEnemy(key, dataOverride) {
+  if (key in i18n(dataOverride).solNodes) {
+    return i18n(dataOverride).solNodes[key].enemy;
   } if (key) {
     return key.split('/').slice(-1)[0];
   }
   return key;
 }
 
-function languageString(key) {
+function languageString(key, dataOverride) {
   const lowerKey = String(key).toLowerCase();
-  if (lowerKey in data.languages) {
-    return data.languages[lowerKey].value;
+  if (lowerKey in i18n(dataOverride).languages) {
+    return i18n(dataOverride).languages[lowerKey].value;
   } if (key) {
     return toTitleCase(splitResourceName(String(key).split('/').slice(-1)[0]));
   }
   return key;
 }
 
-function languageDesc(key) {
+function languageDesc(key, dataOverride) {
   const lowerKey = String(key).toLowerCase();
-  if (lowerKey in data.languages) {
-    return data.languages[lowerKey].desc;
+  if (lowerKey in i18n(dataOverride).languages) {
+    return i18n(dataOverride).languages[lowerKey].desc;
   } if (key) {
     return `[PH] ${toTitleCase(splitResourceName(String(key).split('/').slice(-1)[0]))} Desc`;
   }
   return key;
 }
 
-function missionType(key) {
-  if (key in data.missionTypes) {
-    return data.missionTypes[key].value;
+function missionType(key, dataOverride) {
+  if (key in i18n(dataOverride).missionTypes) {
+    return i18n(dataOverride).missionTypes[key].value;
   } if (key) {
     return toTitleCase(key.replace(/^MT_/, ''));
   }
   return key;
 }
 
-function conclaveMode(key) {
-  if (key in data.conclave.modes) {
-    return data.conclave.modes[key].value;
+function conclaveMode(key, dataOverride) {
+  if (key in i18n(dataOverride).conclave.modes) {
+    return i18n(dataOverride).conclave.modes[key].value;
   }
   return key;
 }
 
-function conclaveCategory(key) {
-  if (key in data.conclave.categories) {
-    return data.conclave.categories[key].value;
+function conclaveCategory(key, dataOverride) {
+  if (key in i18n(dataOverride).conclave.categories) {
+    return i18n(dataOverride).conclave.categories[key].value;
   }
   return key;
 }
 
-function fissureModifier(key) {
-  if (key in data.fissureModifiers) {
-    return data.fissureModifiers[key].value;
+function fissureModifier(key, dataOverride) {
+  if (key in i18n(dataOverride).fissureModifiers) {
+    return i18n(dataOverride).fissureModifiers[key].value;
   }
   return key;
 }
 
-function fissureTier(key) {
-  if (key in data.fissureModifiers) {
-    return data.fissureModifiers[key].num;
+function fissureTier(key, dataOverride) {
+  if (key in i18n(dataOverride).fissureModifiers) {
+    return i18n(dataOverride).fissureModifiers[key].num;
   }
   return key;
 }
 
-function syndicate(key) {
-  if (key in data.syndicates) {
-    return data.syndicates[key].name;
+function syndicate(key, dataOverride) {
+  if (key in i18n(dataOverride).syndicates) {
+    return i18n(dataOverride).syndicates[key].name;
   }
   return key;
 }
 
-function upgrade(key) {
-  if (key in data.upgradeTypes) {
-    return data.upgradeTypes[key].value;
+function upgrade(key, dataOverride) {
+  if (key in i18n(dataOverride).upgradeTypes) {
+    return i18n(dataOverride).upgradeTypes[key].value;
   }
   return key;
 }
 
-function operation(key) {
-  if (key in data.operationTypes) {
-    return data.operationTypes[key].value;
+function operation(key, dataOverride) {
+  if (key in i18n(dataOverride).operationTypes) {
+    return i18n(dataOverride).operationTypes[key].value;
   }
   return key;
 }
 
-function operationSymbol(key) {
-  if (key in data.operationTypes) {
-    return (data.operationTypes[key].symbol || 'x');
+function operationSymbol(key, dataOverride) {
+  if (key in i18n(dataOverride).operationTypes) {
+    return (i18n(dataOverride).operationTypes[key].symbol || 'x');
   }
   return key;
 }
 
-function sortieBoss(key) {
-  if (key in data.sortie.bosses) {
-    return data.sortie.bosses[key].name;
+function sortieBoss(key, dataOverride) {
+  if (key in i18n(dataOverride).sortie.bosses) {
+    return i18n(dataOverride).sortie.bosses[key].name;
   }
   return key;
 }
 
-function sortieFaction(key) {
-  if (key in data.sortie.bosses) {
-    return data.sortie.bosses[key].faction;
+function sortieFaction(key, dataOverride) {
+  if (key in i18n(dataOverride).sortie.bosses) {
+    return i18n(dataOverride).sortie.bosses[key].faction;
   }
   return key;
 }
 
-function sortieModifier(key) {
-  if (key in data.sortie.modifierTypes) {
-    return data.sortie.modifierTypes[key];
+function sortieModifier(key, dataOverride) {
+  if (key in i18n(dataOverride).sortie.modifierTypes) {
+    return i18n(dataOverride).sortie.modifierTypes[key];
   }
   return key;
 }
 
-function sortieModDesc(key) {
-  if (data.sortie.modifierDescriptions && key in data.sortie.modifierDescriptions) {
-    return data.sortie.modifierDescriptions[key];
+function sortieModDesc(key, dataOverride) {
+  if (i18n(dataOverride).sortie.modifierDescriptions
+    && key in i18n(dataOverride).sortie.modifierDescriptions) {
+    return i18n(dataOverride).sortie.modifierDescriptions[key];
   }
   return key;
 }
 
-function region(key) {
-  if (key && data.persistentEnemy[key]) {
-    return data.persistentEnemy[key];
+function region(key, dataOverride) {
+  if (key && i18n(dataOverride).persistentEnemy[key]) {
+    return i18n(dataOverride).persistentEnemy[key];
   }
   return key;
 }

--- a/lib/translation.js
+++ b/lib/translation.js
@@ -33,7 +33,7 @@ function splitResourceName(str) {
   return str.split(/([A-Z]?[^A-Z]*)/g).filter(item => item).join(' ');
 }
 
-const i18n = (locale = 'en') => data[locale];
+const i18n = (locale = 'en') => data[locale] || data;
 
 function faction(key, dataOverride) {
   if (key in i18n(dataOverride).factions) {

--- a/test/system_test.js
+++ b/test/system_test.js
@@ -62,8 +62,6 @@ describe('The parser', function () {
     (() => {
       const w = new WorldState(pcData, { locale: 'es' });
       checkToString(w);
-      // eslint-disable-next-line
-      console.log(JSON.stringify(w));
     }).should.not.throw();
   });
 

--- a/test/system_test.js
+++ b/test/system_test.js
@@ -58,21 +58,50 @@ describe('The parser', function () {
       checkToString(w);
     }).should.not.throw();
   });
+  it('Should parse the PC data to Spanish without throwing', () => {
+    (() => {
+      const w = new WorldState(pcData, { locale: 'es' });
+      checkToString(w);
+      // eslint-disable-next-line
+      console.log(JSON.stringify(w));
+    }).should.not.throw();
+  });
+
   it('Should parse the PS4 data without throwing', () => {
     (() => {
       const w = new WorldState(ps4Data);
       checkToString(w);
     }).should.not.throw();
   });
+  it('Should parse the PS4 data to Spanish without throwing', () => {
+    (() => {
+      const w = new WorldState(ps4Data, { locale: 'es' });
+      checkToString(w);
+    }).should.not.throw();
+  });
+
   it('Should parse the XB1 data without throwing', function () {
     (() => {
       const w = new WorldState(xb1Data);
       checkToString(w);
     }).should.not.throw();
   });
+  it('Should parse the XB1 data to Spanish without throwing', function () {
+    (() => {
+      const w = new WorldState(xb1Data, { locale: 'es' });
+      checkToString(w);
+    }).should.not.throw();
+  });
+
   it('Should parse the Switch data without throwing', function () {
     (() => {
       const w = new WorldState(swiData);
+      checkToString(w);
+    }).should.not.throw();
+  });
+  it('Should parse the Switch data to Spanish without throwing', function () {
+    (() => {
+      const w = new WorldState(swiData, { locale: 'es' });
       checkToString(w);
     }).should.not.throw();
   });

--- a/test/translation_test.js
+++ b/test/translation_test.js
@@ -7,70 +7,120 @@ chai.should();
 
 const translator = rewire('../lib/translation.js');
 
-describe('translation', function () {
-  describe('toTitleCase()', function () {
+describe('translation', () => {
+  describe('toTitleCase()', () => {
     const toTitleCase = translator.__get__('toTitleCase');
 
-    it('requires one string argument', function () {
+    it('requires one string argument', () => {
       (() => { toTitleCase(); }).should.throw(TypeError);
       (() => { toTitleCase('test'); }).should.not.throw();
     });
 
-    it('converts the first letter of every word to uppercase and the others to lowercase', function () {
+    it('converts the first letter of every word to uppercase and the others to lowercase', () => {
       toTitleCase('test').should.equal('Test');
       toTitleCase('test teST').should.equal('Test Test');
     });
   });
 
-  describe('faction()', function () {
-    it('should return a translation of the key if it\'s found in the data', function () {
-      translator.faction('FC_GRINEER').should.equal('Grineer');
+  describe('supports defaulting locale', () => {
+    describe('faction()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.faction('FC_GRINEER').should.equal('Grineer');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.faction('notFound').should.equal('notFound');
+      });
     });
-    it('should return the key if it\'s not found in the data', function () {
-      translator.faction('notFound').should.equal('notFound');
+    describe('node()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.node('SolNode1').should.equal('Galatea (Neptune)');
+      });
+      it('should return the last part of the key if it\'s not found in the data', () => {
+        translator.node('not/Found').should.equal('Found');
+      });
+    });
+    describe('languageString()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.languageString('/lotus/language/alerts/capturedesc1').should.equal('Fugitive Located');
+      });
+      it('should return the last part of the key if it\'s not found in the data', () => {
+        translator.languageString('not/Found').should.equal('Found');
+      });
+    });
+    describe('missionType()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.missionType('MT_EXCAVATE').should.equal('Excavation');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.missionType('notfound').should.equal('Notfound');
+      });
+    });
+    describe('conclaveMode()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.conclaveMode('PVPMODE_ALL').should.equal('Any Mode');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.faction('notfound').should.equal('notfound');
+      });
+    });
+    describe('conclaveCategory()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.conclaveCategory('PVPChallengeTypeCategory_WEEKLY').should.equal('week');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.faction('notfound').should.equal('notfound');
+      });
     });
   });
 
-  describe('node()', function () {
-    it('should return a translation of the key if it\'s found in the data', function () {
-      translator.node('SolNode1').should.equal('Galatea (Neptune)');
+  describe('supports overriding locale', () => {
+    describe('faction()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.faction('FC_GRINEER', 'es').should.equal('Grineer');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.faction('notFound', 'es').should.equal('notFound');
+      });
     });
-    it('should return the last part of the key if it\'s not found in the data', function () {
-      translator.node('not/Found').should.equal('Found');
+    describe('node()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.node('SolNode1', 'es').should.equal('Galatea (Neptuno)');
+      });
+      it('should return the last part of the key if it\'s not found in the data', () => {
+        translator.node('not/Found', 'es').should.equal('Found');
+      });
     });
-  });
-
-  describe('languageString()', function () {
-    it('should return a translation of the key if it\'s found in the data', function () {
-      translator.languageString('/lotus/language/alerts/capturedesc1').should.equal('Fugitive Located');
+    describe('languageString()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.languageString('/lotus/language/alerts/capturedesc1', 'es').should.equal('Fugitivo localizado');
+      });
+      it('should return the last part of the key if it\'s not found in the data', () => {
+        translator.languageString('not/Found', 'es').should.equal('Found');
+      });
     });
-    it('should return the last part of the key if it\'s not found in the data', function () {
-      translator.languageString('not/Found').should.equal('Found');
+    describe('missionType()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.missionType('MT_EXCAVATE', 'es').should.equal('Excavación');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.missionType('notfound', 'es').should.equal('Notfound');
+      });
     });
-  });
-
-  describe('missionType()', function () {
-    it('should return a translation of the key if it\'s found in the data', function () {
-      translator.missionType('MT_EXCAVATE').should.equal('Excavation');
+    describe('conclaveMode()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.conclaveMode('PVPMODE_ALL', 'es').should.equal('Cualquier modo');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.faction('notfound', 'es').should.equal('notfound');
+      });
     });
-    it('should return the key if it\'s not found in the data', function () {
-      translator.missionType('notfound').should.equal('Notfound');
-    });
-  });
-  describe('conclaveMode()', function () {
-    it('should return a translation of the key if it\'s found in the data', function () {
-      translator.conclaveMode('PVPMODE_ALL').should.equal('Any Mode');
-    });
-    it('should return the key if it\'s not found in the data', function () {
-      translator.faction('notfound').should.equal('notfound');
-    });
-  });
-  describe('conclaveCategory()', function () {
-    it('should return a translation of the key if it\'s found in the data', function () {
-      translator.conclaveCategory('PVPChallengeTypeCategory_WEEKLY').should.equal('week');
-    });
-    it('should return the key if it\'s not found in the data', function () {
-      translator.faction('notfound').should.equal('notfound');
+    describe('conclaveCategory()', () => {
+      it('should return a translation of the key if it\'s found in the data', () => {
+        translator.conclaveCategory('PVPChallengeTypeCategory_WEEKLY', 'es').should.equal('week');
+      });
+      it('should return the key if it\'s not found in the data', () => {
+        translator.faction('notfound', 'es').should.equal('notfound');
+      });
     });
   });
 });


### PR DESCRIPTION
closes #36 

Use worldstate-data translations to provide translations.
Locale can be passed as a dependency to the parser.
Parser dependencies now fill in default objects where they're not overridden.