### PR TITLE
Ensure CetusCycle#activation ISO

### DIFF
--- a/lib/CetusCycle.js
+++ b/lib/CetusCycle.js
@@ -65,7 +65,7 @@ class CetusCycle extends WorldstateObject {
      * The date and time at which the event started
      * @type {Date}
      */
-    this.activation = ec.start;
+    this.activation = new Date(ec.start);
 
     /**
      * Whether or not this it's daytime


### PR DESCRIPTION
Making sure that CetusCycle#activation, when JSON.string'd becomes an iso date string.