### PR TITLE
Steel path end of week date fix

### DIFF
--- a/lib/SteelPathOffering.js
+++ b/lib/SteelPathOffering.js
@@ -15,7 +15,7 @@ function getFirstDayOfWeek() {
 
 function getLastDayOfWeek() {
   const last = new Date(getFirstDayOfWeek());
-  last.setUTCDate(last.getUTCDate() + 4);
+  last.setUTCDate(last.getUTCDate() + 6);
   last.setUTCHours(23);
   last.setUTCMinutes(59);
   last.setUTCSeconds(59);


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)

Steel Path offerings should end at end of Sunday UTC instead of Friday UTC.
The end date is wrong.

In SteelPathOffering.js, getLastDayOfWeek() has been updated to offset by 6 (which is the day of week for Sunday) instead of the original 4.

This is a duplicate PR to #333, just from within the repository

---

### Evidence/screenshot/link to line

This has been tested in a beta version of Warframe Hub, which depends on parser.
![image](https://user-images.githubusercontent.com/1594432/138354727-a9bc08fa-e3bc-4faf-a554-8f21e0b904b4.png)

