### PR TITLE
feat: Add a faction key to Syndicates and Sorties

### DIFF
--- a/lib/Sortie.js
+++ b/lib/Sortie.js
@@ -79,6 +79,12 @@ class Sortie extends WorldstateObject {
     this.faction = translator.sortieFaction(data.Boss, locale);
 
     /**
+     * The sortie's faction
+     * @type {string}
+     */
+    this.factionKey = translator.sortieFaction(data.boss, 'en');
+
+    /**
      * Whether or not this is expired (at time of object creation)
      * @type {boolean}
      */

--- a/lib/SyndicateMission.js
+++ b/lib/SyndicateMission.js
@@ -68,6 +68,12 @@ class SyndicateMission extends WorldstateObject {
     this.syndicate = translator.syndicate(data.Tag, locale);
 
     /**
+     * The syndicate that is offering the mission
+     * @type {string}
+     */
+    this.syndicateKey = translator.syndicate(data.Tag, 'en');
+
+    /**
      * The nodes on which the missions are taking place
      * @type {Array.<string>}
      */


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Added a `factionkey/SyndicateKey` to syndicates and Sorties for easier string matching

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
