### PR TITLE
fix: a typo in `factionKey`

### DIFF
--- a/lib/Mission.js
+++ b/lib/Mission.js
@@ -68,7 +68,7 @@ module.exports = class Mission {
      * The factions that the players must fight in the mission
      * @type {string}
      */
-    this.faction = translator.faction(data.faction, 'en');
+    this.factionKey = translator.faction(data.faction, 'en');
 
     /**
      * The mission's reward


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixed a typo in factions for Missions, should be `factionKey` instead of a second `faction`

---

### Evidence/screenshot/link to line

You can see my fix [on this line](#71) for where the new data exists

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
