### PR TITLE
fix: translate news when there's a lang

### DIFF
--- a/lib/News.js
+++ b/lib/News.js
@@ -5,7 +5,7 @@ const WorldstateObject = require('./WorldstateObject');
 const updateReg = /(update|hotfix)/i;
 const primeAccessReg = /(access)/i;
 const streamReg = /(devstream|prime-time|warframeinternational|stream)/i;
-const langString = /\/Lotus\/Language\\/i;
+const langString = /(\/Lotus\/Language\/)/i;
 
 /**
  * Represents a game news item

--- a/lib/News.js
+++ b/lib/News.js
@@ -5,6 +5,7 @@ const WorldstateObject = require('./WorldstateObject');
 const updateReg = /(update|hotfix)/i;
 const primeAccessReg = /(access)/i;
 const streamReg = /(devstream|prime-time|warframeinternational|stream)/i;
+const langString = /\/Lotus\/Language\\/i;
 
 /**
  * Represents a game news item
@@ -15,10 +16,11 @@ class News extends WorldstateObject {
    * @param   {Object}             data            The news data
    * @param   {Dependency}         deps            The dependencies object
    * @param   {MarkdownSettings}   deps.mdConfig   The markdown settings
+   * @param   {Translator}         deps.translator The string translator
    * @param   {TimeDateFunctions}  deps.timeDate   The time and date functions
    * @param   {locale}             deps.locale     Locale to use for determining language
    */
-  constructor(data, { mdConfig, timeDate, locale }) {
+  constructor(data, { mdConfig, translator, timeDate, locale }) {
     super(data, { timeDate });
 
     /**
@@ -42,6 +44,9 @@ class News extends WorldstateObject {
      * @type {string}
      */
     this.message = (data.Messages.find((msg) => msg.LanguageCode === locale) || { Message: '' }).Message;
+    if (langString.test(this.message)) {
+      this.message = translator.languageString(this.message, locale);
+    }
 
     /**
      * The link to the forum post
@@ -115,6 +120,10 @@ class News extends WorldstateObject {
      */
     this.translations = {};
     data.Messages.forEach((message) => {
+      if (langString.test(message)) {
+        this.translations[message.LanguageCode] = translator.languageString(message, message.LanguageCode);
+      }
+
       this.translations[message.LanguageCode] = message.Message;
     });
 

--- a/test/data/LanguageNews.json
+++ b/test/data/LanguageNews.json
@@ -2,7 +2,7 @@
     "_id": { "$oid": "1234sg" },
     "Activation": { "sec": 1 },
     "Expiry": { "sec": 3 },
-    "Messages": [{ "Message": "/Lotus/Language/test/test" }],
+    "Messages": [{ "Message": "/Lotus/Language/Test" }],
     "Date": { "sec": 1000 },
     "Prop": "https://forums.warframe.com/"
   }

--- a/test/data/LanguageNews.json
+++ b/test/data/LanguageNews.json
@@ -1,0 +1,8 @@
+{
+    "_id": { "$oid": "1234sg" },
+    "Activation": { "sec": 1 },
+    "Expiry": { "sec": 3 },
+    "Messages": [{ "Message": "/Lotus/Language/test/test" }],
+    "Date": { "sec": 1000 },
+    "Prop": "https://forums.warframe.com/"
+  }

--- a/test/unit/news.spec.js
+++ b/test/unit/news.spec.js
@@ -151,7 +151,7 @@ describe('News', () => {
 
     it('Should return a lang when a lang is supplied', () => {
       const n = new News(languageTestData, { mdConfig, timeDate, translator });
-      n.getTitle('en').should.equal('/Lotus/Language/test/test');
+      n.getTitle('en').should.equal('Test');
     });
 
     it('should return the localized message when a translation is present', () => {

--- a/test/unit/news.spec.js
+++ b/test/unit/news.spec.js
@@ -10,12 +10,10 @@ const timeDate = require('../mocks/timeDate');
 
 const testData = require('../data/News.json');
 const realTestData = require('../data/RealNews.json');
+const languageTestData = require('../data/LanguageNews.json');
 
 const locale = 'en';
-
-const translator = {
-  node: () => 'node',
-};
+const translator = require('../../lib/translation');
 
 describe('News', () => {
   describe('#constructor()', () => {
@@ -149,6 +147,11 @@ describe('News', () => {
     it('should return the original message when no translations are present', () => {
       const n = new News(testData, { mdConfig, timeDate, translator });
       n.getTitle('en').should.equal('test');
+    });
+
+    it('Should return a lang when a lang is supplied', () => {
+      const n = new News(languageTestData, { mdConfig, timeDate, translator });
+      n.getTitle('en').should.equal('/Lotus/Language/test/test');
     });
 
     it('should return the localized message when a translation is present', () => {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Looks like DE is using a lang for it's discord join entry, this will in theory only translate the string when one is detected for both `message` and `translations`.

---

### Evidence/screenshot/link to line
```json
{
    "id": "62d31b87106360aa5703954d",
    "message": "/Lotus/Language/CommunityMessages/JoinDiscord",
    "link": "https://discord.com/invite/playwarframe",
    "imageLink": "https://i.imgur.com/CNrsc7V.png",
    "priority": false,
    "date": "2022-07-16T20:10:00.000Z",
    "eta": "66d 19h 13m 55s ago",
    "update": false,
    "primeAccess": false,
    "stream": false,
    "translations": {
      "en": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "fr": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "it": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "de": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "es": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "pt": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "ru": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "pl": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "uk": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "tr": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "ja": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "zh": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "ko": "/Lotus/Language/CommunityMessages/JoinDiscord",
      "tc": "/Lotus/Language/CommunityMessages/JoinDiscord"
    },
    "asString": "[66d 19h 13m 55s ago] [/Lotus/Language/CommunityMessages/JoinDiscord](https://discord.com/invite/playwarframe)"
  }
  ```

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
