### PR TITLE
fix: message not being passed correctly to translations

### DIFF
--- a/lib/News.js
+++ b/lib/News.js
@@ -120,8 +120,8 @@ class News extends WorldstateObject {
      */
     this.translations = {};
     data.Messages.forEach((message) => {
-      if (langString.test(message)) {
-        this.translations[message.LanguageCode] = translator.languageString(message, message.LanguageCode);
+      if (langString.test(message.Message)) {
+        this.translations[message.LanguageCode] = translator.languageString(message.Message, message.LanguageCode);
       }
 
       this.translations[message.LanguageCode] = message.Message;


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Yeah so I messed up that part, when checking the translations string I forgot to add `message.Message`.

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
