### PR TITLE
fix: translator being canceled out

### DIFF
--- a/lib/News.js
+++ b/lib/News.js
@@ -120,11 +120,11 @@ class News extends WorldstateObject {
      */
     this.translations = {};
     data.Messages.forEach((message) => {
+      this.translations[message.LanguageCode] = message.Message;
+
       if (langString.test(message.Message)) {
         this.translations[message.LanguageCode] = translator.languageString(message.Message, message.LanguageCode);
       }
-
-      this.translations[message.LanguageCode] = message.Message;
     });
 
     /**


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Mistake number 2 cancelling out the work that was done with `translator` with the second call to `this.translations[message.LanguageCode]`

---

### Evidence/screenshot/link to line
```js
    /**
     * Translation of the news item
     * @type {Object.<string, string>}
     */
    this.translations = {};
    data.Messages.forEach((message) => {
      if (langString.test(message.Message)) {
        this.translations[message.LanguageCode] = translator.languageString(message.Message, message.LanguageCode);
      }

      this.translations[message.LanguageCode] = message.Message;
    });
```

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **[No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
