### PR TITLE
fix: make arbitration undefined when empty

### DIFF
--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -91,9 +91,7 @@ function parseArray(ParserClass, dataArray, deps, uniqueField) {
       utemp[obj[uniqueField]] = obj;
     });
     return Array.from(arr).filter((obj) => {
-      if (Object.prototype.hasOwnProperty.call(obj, 'active')) {
-        return obj.active;
-      }
+      if (typeof obj?.active !== 'undefined') return obj.active;
       /* istanbul ignore next */
       return true;
     });
@@ -305,6 +303,10 @@ module.exports = class WorldState {
        */
       arbitration: this.arbitration,
     } = externalMissions);
+
+    if (!this.arbitration || !Object.keys(this.arbitration).length) {
+      this.arbitration = undefined;
+    }
 
     /**
      * Current syndicate outposts

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -91,7 +91,7 @@ function parseArray(ParserClass, dataArray, deps, uniqueField) {
       utemp[obj[uniqueField]] = obj;
     });
     return Array.from(arr).filter((obj) => {
-      if (typeof obj?.active !== 'undefined') return obj.active;
+      if (obj && obj.active && typeof obj.active !== 'undefined') return obj.active;
       /* istanbul ignore next */
       return true;
     });

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -47,11 +47,13 @@ describe('WorldState (integration)', () => {
             }
           }).should.not.throw();
 
-          wsl?.news?.forEach((article) => {
-            if (article.message.toLowerCase().includes('stream')) {
-              article.should.include({ stream: true });
-            }
-          });
+          wsl &&
+            wsl.news &&
+            wsl.news.forEach((article) => {
+              if (article.message.toLowerCase().includes('stream')) {
+                article.should.include({ stream: true });
+              }
+            });
           /* Easy debugging! */
           if (process.env.CI) {
             return fs.writeFile(

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -2,7 +2,6 @@
 
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
-const rewire = require('rewire');
 const fs = require('fs').promises;
 
 const fetch = require('node-fetch');
@@ -18,7 +17,7 @@ const logger = {
 chai.should();
 chai.use(sinonChai);
 
-const WorldState = rewire('../../lib/WorldState.js');
+const WorldState = require('../../lib/WorldState');
 
 describe('WorldState (integration)', () => {
   describe('#constructor()', async () => {

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -27,24 +27,38 @@ describe('WorldState (integration)', () => {
       ['pc'].map(async function (platform) {
         it(`should parse live ${platform} worldstate data`, async function () {
           this.timeout = 10000; // allow 10 seconds to parse the worldstate
-          const url = `https://content.warframe.com/dynamic/worldState.php`;
-          const ws = await fetch(url).then((d) => d.text());
+
+          const { kuvaData, ws } = await fetch('https://10o.io/arbitrations.json')
+            .then((res) => res.json())
+            .then(async (semlar) => ({
+              kuvaData: semlar,
+              ws: await fetch('https://content.warframe.com/dynamic/worldState.php').then((res) => res.text()),
+            }));
 
           let wsl;
           (() => {
-            wsl = new WorldState(ws, { logger, locale: 'en' });
+            try {
+              // once without kuva data
+              wsl = new WorldState(ws, { logger, locale: 'en' });
+              wsl = new WorldState(ws, { logger, locale: 'en', kuvaData });
+            } catch (e) {
+              console.error(e);
+              throw e;
+            }
           }).should.not.throw();
 
-          wsl.news.forEach((article) => {
+          wsl?.news?.forEach((article) => {
             if (article.message.toLowerCase().includes('stream')) {
               article.should.include({ stream: true });
             }
           });
           /* Easy debugging! */
-          return fs.writeFile(
-            path.resolve(`./data.${platform}.json`),
-            JSON.stringify(wsl.syndicateMissions.find((m) => m.syndicateKey === 'Ostrons'))
-          );
+          if (process.env.CI) {
+            return fs.writeFile(
+              path.resolve(`./data.${platform}.json`),
+              JSON.stringify(wsl.syndicateMissions.find((m) => m.syndicateKey === 'Ostrons'))
+            );
+          }
         });
       })
     );

--- a/test/unit/system.spec.js
+++ b/test/unit/system.spec.js
@@ -10,7 +10,7 @@ const sentientMock = require('../data/anomaly.json');
 
 chai.should();
 
-const checkToString = function checkToString(worldState) {
+const checkToString = (worldState) => {
   Object.getOwnPropertyNames(worldState).forEach((p) => {
     if (Array.isArray(worldState[p])) {
       worldState[p].forEach((m) => m.toString());
@@ -21,7 +21,7 @@ const checkToString = function checkToString(worldState) {
 };
 
 const data = {};
-const platforms = ['pc', 'ps4', 'xb1', 'swi'];
+const platforms = ['pc'];
 let w;
 
 const getPData = (p) =>
@@ -60,8 +60,14 @@ describe('The parser', () => {
       };
 
       (() => {
-        w = new WorldState(data[platform], deps);
-        checkToString(w);
+        try {
+          w = new WorldState(data[platform], deps);
+          checkToString(w);
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error(e);
+          throw e;
+        }
       }).should.not.throw();
     });
   });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #419 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->
When data doesn't come back from semlar, make sure data gets filled

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->
default back to undefined if the keys of the arbitration are empty

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
