### PR TITLE
fix: Nightwave challenge `isDaily` default to false

### DIFF
--- a/lib/NightwaveChallenge.js
+++ b/lib/NightwaveChallenge.js
@@ -23,7 +23,7 @@ class NightwaveChallenge extends WorldstateObject {
      * Whether or not this is a daily challenge
      * @type {Boolean}
      */
-    this.isDaily = data.Daily;
+    this.isDaily = data.Daily || false;
 
     /**
      * Whether or not the challenge is an elite challenge

--- a/test/unit/nightwave.spec.js
+++ b/test/unit/nightwave.spec.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 
 chai.should();
 
+const { expect } = require('chai');
 const Nightwave = require('../../lib/Nightwave');
 const mdConfig = require('../data/markdown.json');
 const nwdata = require('../data/Nightwave.json');
@@ -31,6 +32,13 @@ describe('Nightwave', () => {
     it('should parse nightwave data', () => {
       (() => {
         new Nightwave(nwdata, deps);
+      }).should.not.throw();
+    });
+    it('isDaily should be present', () => {
+      (() => {
+        const n = new Nightwave(nwdata, deps);
+        const challenges = n.possibleChallenges.concat(n.activeChallenges);
+        challenges.forEach((e) => expect(typeof e.isDaily !== 'undefined').to.be.true);
       }).should.not.throw();
     });
   });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
When parsing nightwave weekly challenges `isDaily` would disappear from the data instead of defaulting to false.

---

### Reproduction steps
1. parse worldstate.

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
