### PR TITLE
fix(types): fissure, zariman, cambion syntax

### DIFF
--- a/lib/CambionCycle.js
+++ b/lib/CambionCycle.js
@@ -7,7 +7,7 @@ const WorldstateObject = require('./WorldstateObject');
  * @extends {WorldstateObject}
  * @property {string} timeLeft time rendering of amount of time left
  */
-module.exports = class CambionCycle extends WorldstateObject {
+class CambionCycle extends WorldstateObject {
   /**
    * @param   {CetusCycle}        cetusCycle Match data from cetus cycle for data
    * @param   {Object}            deps            The dependencies object
@@ -25,10 +25,12 @@ module.exports = class CambionCycle extends WorldstateObject {
   }
 
   /**
-   * Get whether or not the event has expired
+   * Get whether the event has expired
    * @returns {boolean}
    */
   getExpired() {
     return this.timeDate.fromNow(this.expiry) < 0;
   }
-};
+}
+
+module.exports = CambionCycle;

--- a/lib/Fissure.js
+++ b/lib/Fissure.js
@@ -6,7 +6,7 @@ const WorldstateObject = require('./WorldstateObject');
  * Represents a fissure mission
  * @extends {WorldstateObject}
  */
-module.exports = class Fissure extends WorldstateObject {
+class Fissure extends WorldstateObject {
   /**
    * @param   {Object}             data            The fissure data
    * @param   {Object}             deps            The dependencies object
@@ -137,4 +137,6 @@ module.exports = class Fissure extends WorldstateObject {
   toString() {
     return `[${this.getETAString()}] ${this.tier} fissure at ${this.node} - ${this.enemy} ${this.missionType}`;
   }
-};
+}
+
+module.exports = Fissure;

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -34,6 +34,7 @@ const Kuva = require('./Kuva');
 const SentientOutpost = require('./SentientOutpost');
 const CambionCycle = require('./CambionCycle');
 const SteelPathOffering = require('./SteelPathOffering');
+const Dependency = require('./supporting/Dependency'); // eslint-disable-line no-unused-vars
 
 // needed for type declarations
 const MarkdownSettings = require('./supporting/MarkdownSettings');
@@ -79,8 +80,8 @@ const defaultDeps = {
  * @param {Object} ParserClass class for parsing data
  * @param {Array<BaseContentObject>} dataArray array of raw data
  * @param {Dependency} deps shared dependency object
- * @param {*} uniqueField field to treat as unique
- * @returns {WorldstateObject}
+ * @param {*} [uniqueField] field to treat as unique
+ * @returns {WorldstateObject[]}
  */
 function parseArray(ParserClass, dataArray, deps, uniqueField) {
   const arr = (dataArray || []).map((d) => new ParserClass(d, deps));

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -164,7 +164,7 @@ module.exports = class WorldState {
 
     /**
      * The current fissures: 'ActiveMissions' & 'VoidStorms'
-     * @type {Array.<News>}
+     * @type {Array.<Fissure>}
      */
     this.fissures = parseArray(deps.Fissure, data.ActiveMissions, deps).concat(
       parseArray(deps.Fissure, data.VoidStorms, deps)

--- a/lib/ZarimanCycle.js
+++ b/lib/ZarimanCycle.js
@@ -13,7 +13,7 @@ const stateMaximum = 9000000;
  * Represents the current Zariman Corpus/Grineer Cycle
  * @extends {WorldstateObject}
  */
-module.exports = class ZarimanCycle extends WorldstateObject {
+class ZarimanCycle extends WorldstateObject {
   /**
    * @param   {Date}              bountiesEndDate The current zariman cycle expiry
    * @param   {Object}            deps            The dependencies object
@@ -138,4 +138,6 @@ module.exports = class ZarimanCycle extends WorldstateObject {
 
     return lines.join(this.mdConfig.lineEnd);
   }
-};
+}
+
+module.exports = ZarimanCycle;

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -41,7 +41,7 @@ describe('WorldState (integration)', () => {
               wsl = new WorldState(ws, { logger, locale: 'en' });
               wsl = new WorldState(ws, { logger, locale: 'en', kuvaData });
             } catch (e) {
-              console.error(e);
+              console.error(e); // eslint-disable-line no-console
               throw e;
             }
           }).should.not.throw();


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
This PR fixes [#440](https://github.com/WFCD/warframe-worldstate-parser/issues/440)

closes #440 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

The error is already described in [#440](https://github.com/WFCD/warframe-worldstate-parser/issues/440)

A little summary : 

The type generated by the `build:types` command provided incorrect types for the property `fissures` in typescript projects, reporting this property as an array of News instead of Fissure

This PR fixes this minor issue



---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
