### PR TITLE
feat: Show the unique name for the item on sale

### DIFF
--- a/lib/DailyDeal.js
+++ b/lib/DailyDeal.js
@@ -36,6 +36,12 @@ class DailyDeal {
     this.item = translator.languageString(data.StoreItem, locale);
 
     /**
+     * The uniqueName for the item on sale.
+     * @type {string}
+     */
+    this.uniqueName = data.StoreItem;
+
+    /**
      * The date and time at which the deal will expire
      * @type {Date}
      */


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Added the ability to show the unique name of an item. Makes it easier to find the item in warframe-items.

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
