### PR TITLE
feat: Deprecated voidTrader endpoint for voidTraders

### DIFF
--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -200,7 +200,9 @@ module.exports = class WorldState {
      * The state of the Void Trader
      * @type {VoidTrader}
      */
-    [this.voidTrader] = parseArray(deps.VoidTrader, data.VoidTraders, deps);
+    const voidTraderArray = parseArray(deps.VoidTrader, data.VoidTraders, deps);
+    voidTraderArray.sort((a, b) => b.inventory.length - a.inventory.length);
+    this.voidTraders = voidTraderArray;
 
     /**
      * The current daily deals

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -201,7 +201,7 @@ module.exports = class WorldState {
      * @type {VoidTrader}
      */
     const voidTraderArray = parseArray(deps.VoidTrader, data.VoidTraders, deps);
-    voidTraderArray.sort((a, b) => b.inventory.length - a.inventory.length);
+    voidTraderArray.sort((a, b) => Date.parse(a.activation) - Date.parse(b.activation));
     this.voidTraders = voidTraderArray;
 
     /**

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -199,10 +199,18 @@ module.exports = class WorldState {
     /**
      * The state of the Void Trader
      * @type {VoidTrader}
+     * @deprecated
      */
-    const voidTraderArray = parseArray(deps.VoidTrader, data.VoidTraders, deps);
-    voidTraderArray.sort((a, b) => Date.parse(a.activation) - Date.parse(b.activation));
-    this.voidTraders = voidTraderArray;
+    [this.voidTrader] = parseArray(deps.VoidTrader, data.VoidTraders, deps);
+
+    /**
+     * The state of all Void Traders
+     * @type {VoidTrader[]}
+     */
+    this.voidTraders = parseArray(deps.VoidTrader, data.VoidTraders, deps).sort(
+      (a, b) => Date.parse(a.activation) - Date.parse(b.activation)
+    );
+    [this.voidTrader] = this.voidTraders;
 
     /**
      * The current daily deals

--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -197,19 +197,18 @@ module.exports = class WorldState {
     this.darkSectors = parseArray(deps.DarkSector, data.BadlandNodes, deps);
 
     /**
-     * The state of the Void Trader
-     * @type {VoidTrader}
-     * @deprecated
-     */
-    [this.voidTrader] = parseArray(deps.VoidTrader, data.VoidTraders, deps);
-
-    /**
      * The state of all Void Traders
      * @type {VoidTrader[]}
      */
     this.voidTraders = parseArray(deps.VoidTrader, data.VoidTraders, deps).sort(
       (a, b) => Date.parse(a.activation) - Date.parse(b.activation)
     );
+
+    /**
+     * The state of the Void Trader
+     * @type {VoidTrader}
+     * @deprecated
+     */
     [this.voidTrader] = this.voidTraders;
 
     /**


### PR DESCRIPTION
### What did you fix?
closes #461

---

### Reproduction steps

- When the void trader array was de-structured, specifically during tennocon baro visits, it would serve a different void trader each time. 
- Endpoint now returns an array sorted by inventory length in descending order, so tennocon baro always appears first (assuming he will always have a larger inventory than normal baro)

---
### Evidence/screenshot/link to line

Fix is on lines 203 - 205

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
