### PR TITLE
feat: expose `uniqueName` for `VoidTraderItem`s

### DIFF
--- a/lib/models/VoidTraderItem.js
+++ b/lib/models/VoidTraderItem.js
@@ -17,6 +17,7 @@ class VoidTraderItem {
    * @param   {string}             deps.locale     Locale to use for translations
    */
   constructor({ ItemType, PrimePrice, RegularPrice }, { translator, locale }) {
+    this.uniqueName = ItemType;
     this.item = translator.languageString(ItemType, locale);
     this.ducats = Number.parseInt(PrimePrice, 10);
     this.credits = Number.parseInt(RegularPrice, 10);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Exposes and item's `uniqueName`. Should make it easier to find items in warframe-items, except of course new items.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
