### PR TITLE
ci: add dependabot version updates for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,21 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "00:00"
+    commit-message:
+      prefix: ""
+      prefix-development: "dev"
+      include: "scope"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    rebase-strategy: "auto"
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Use Dependabot to keep github actions updated

---

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes*
- Is is a bug fix, feature request, or enhancement? **Maintenance**
