### PR TITLE
fix: factionless worldevent#tostring

### DIFF
--- a/lib/models/WorldEvent.js
+++ b/lib/models/WorldEvent.js
@@ -259,8 +259,7 @@ export default class WorldEvent extends WorldstateObject {
     let lines = [];
     if (this.faction) {
       lines.push(`${this.description} : ${this.faction}`);
-    }
-    else {
+    } else {
       lines.push(this.description);
     }
 

--- a/lib/models/WorldEvent.js
+++ b/lib/models/WorldEvent.js
@@ -256,7 +256,13 @@ export default class WorldEvent extends WorldstateObject {
    * @returns {string} the event's string representation
    */
   toString() {
-    let lines = [`${this.description} : ${this.faction}`];
+    let lines = [];
+    if (this.faction) {
+      lines.push(`${this.description} : ${this.faction}`);
+    }
+    else {
+      lines.push(this.description);
+    }
 
     if (this.scoreLocTag && this.maximumScore) {
       lines.push(`${this.scoreLocTag} : ${this.maximumScore}`);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
![image](https://github.com/WFCD/warframe-worldstate-parser/assets/63328889/273d37b8-cb39-4b29-b1e8-ba3b8131fb7e)

---

### Reproduction steps
/pc/events

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **N/A**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
