### PR TITLE
fix: modified sentient outpost regex to only target the `sfn` key-value

### DIFF
--- a/lib/models/SentientOutpost.js
+++ b/lib/models/SentientOutpost.js
@@ -43,8 +43,8 @@ export default class SentientOutpost {
   #node;
   constructor(data, { locale, sentientData, logger }) {
     if (!data) data = '{"sfn":000}';
-    const sfn = data.match(/"sfn":(\d+)/g)[0];
-    [this.#node] = sfn.match(/\d{3}/g) || ['000'];
+    const json = JSON.parse(data);
+    this.#node = json.sfn || '000';
     const id = `CrewBattleNode${this.#node}`;
     /* istanbul ignore if */
     if (this.#node === '000') {

--- a/lib/models/SentientOutpost.js
+++ b/lib/models/SentientOutpost.js
@@ -43,7 +43,8 @@ export default class SentientOutpost {
   #node;
   constructor(data, { locale, sentientData, logger }) {
     if (!data) data = '{"sfn":000}';
-    [this.#node] = data.match(/\d{3}/g) || ['000'];
+    const sfn = data.match(/"sfn":(\d+)/g)[0];
+    [this.#node] = sfn.match(/\d{3}/g) || ['000'];
     const id = `CrewBattleNode${this.#node}`;
     /* istanbul ignore if */
     if (this.#node === '000') {

--- a/test/data/Tmp.js
+++ b/test/data/Tmp.js
@@ -1,0 +1,19 @@
+export default {
+  Tmp: JSON.stringify({
+    prisbegin: '1687363200',
+    prisend: '1688572800',
+    cavabegin: '1690761600',
+    PurchasePlatformLockEnabled: true,
+    lqo9: {
+      mt: ['Survival', 'Extermination', 'Alchemy'],
+      mv: ['UnpoweredCapsules', 'FortifiedFoes', 'AlchemicalShields'],
+      c: [
+        ['RegeneratingEnemies', 'PointBlank'],
+        ['Quicksand', 'EMPBlackHole'],
+        ['Deflectors', 'AcceleratedEnemies'],
+      ],
+      fv: ['ContactDamage', 'Withering', 'Gearless', 'Exhaustion'],
+    },
+    sfn: 554,
+  }),
+};

--- a/test/data/Tmp.js
+++ b/test/data/Tmp.js
@@ -1,19 +1,19 @@
-export default {
-  Tmp: JSON.stringify({
-    prisbegin: '1687363200',
-    prisend: '1688572800',
-    cavabegin: '1690761600',
-    PurchasePlatformLockEnabled: true,
-    lqo9: {
-      mt: ['Survival', 'Extermination', 'Alchemy'],
-      mv: ['UnpoweredCapsules', 'FortifiedFoes', 'AlchemicalShields'],
-      c: [
-        ['RegeneratingEnemies', 'PointBlank'],
-        ['Quicksand', 'EMPBlackHole'],
-        ['Deflectors', 'AcceleratedEnemies'],
-      ],
-      fv: ['ContactDamage', 'Withering', 'Gearless', 'Exhaustion'],
-    },
-    sfn: 554,
-  }),
-};
+const tmp = JSON.stringify({
+  prisbegin: '1687363200',
+  prisend: '1688572800',
+  cavabegin: '1690761600',
+  PurchasePlatformLockEnabled: true,
+  lqo9: {
+    mt: ['Survival', 'Extermination', 'Alchemy'],
+    mv: ['UnpoweredCapsules', 'FortifiedFoes', 'AlchemicalShields'],
+    c: [
+      ['RegeneratingEnemies', 'PointBlank'],
+      ['Quicksand', 'EMPBlackHole'],
+      ['Deflectors', 'AcceleratedEnemies'],
+    ],
+    fv: ['ContactDamage', 'Withering', 'Gearless', 'Exhaustion'],
+  },
+  sfn: 554,
+});
+
+export default tmp;

--- a/test/data/Tmp.json
+++ b/test/data/Tmp.json
@@ -1,3 +1,0 @@
-{
-    "Tmp": "{\"prisbegin\":\"1687363200\",\"prisend\":\"1688572800\",\"cavabegin\":\"1690761600\",\"PurchasePlatformLockEnabled\":true,\"lqo9\":{\"mt\":[\"Survival\",\"Extermination\",\"Alchemy\"],\"mv\":[\"UnpoweredCapsules\",\"FortifiedFoes\",\"AlchemicalShields\"],\"c\":[[\"RegeneratingEnemies\",\"PointBlank\"],[\"Quicksand\",\"EMPBlackHole\"],[\"Deflectors\",\"AcceleratedEnemies\"]],\"fv\":[\"ContactDamage\",\"Withering\",\"Gearless\",\"Exhaustion\"]},\"sfn\":554}"
-}

--- a/test/data/Tmp.json
+++ b/test/data/Tmp.json
@@ -1,0 +1,3 @@
+{
+    "Tmp": "{\"prisbegin\":\"1687363200\",\"prisend\":\"1688572800\",\"cavabegin\":\"1690761600\",\"PurchasePlatformLockEnabled\":true,\"lqo9\":{\"mt\":[\"Survival\",\"Extermination\",\"Alchemy\"],\"mv\":[\"UnpoweredCapsules\",\"FortifiedFoes\",\"AlchemicalShields\"],\"c\":[[\"RegeneratingEnemies\",\"PointBlank\"],[\"Quicksand\",\"EMPBlackHole\"],[\"Deflectors\",\"AcceleratedEnemies\"]],\"fv\":[\"ContactDamage\",\"Withering\",\"Gearless\",\"Exhaustion\"]},\"sfn\":554}"
+}

--- a/test/unit/sentientOutpost.spec.js
+++ b/test/unit/sentientOutpost.spec.js
@@ -1,0 +1,27 @@
+import * as chai from 'chai';
+import sinonChai from 'sinon-chai';
+
+import SentientOutpost from '../../lib/models/SentientOutpost.js';
+import Tmp from '../data/Tmp.json' assert { type: 'json' };
+
+chai.should();
+chai.use(sinonChai);
+
+describe('SentientOutpost', function () {
+  describe('#constructor()', function () {
+    it('should be able to handle some raw data', () => {
+      const outpost = new SentientOutpost(Tmp.Tmp, { locale: 'en', logger: console });
+
+      outpost.id.should.equal('CrewBattleNode554:true');
+      outpost.mission.node.should.equal('H-2 Cloud (Veil)');
+    });
+    it('should throw TypeError when called with no argument or an invalid argument', function () {
+      (() => {
+        new SentientOutpost();
+      }).should.throw(TypeError);
+      (() => {
+        new SentientOutpost({});
+      }).should.throw(TypeError);
+    });
+  });
+});

--- a/test/unit/sentientOutpost.spec.js
+++ b/test/unit/sentientOutpost.spec.js
@@ -10,7 +10,7 @@ chai.use(sinonChai);
 describe('SentientOutpost', function () {
   describe('#constructor()', function () {
     it('should be able to handle some raw data', () => {
-      const outpost = new SentientOutpost(data.Tmp, { locale: 'en', logger: console });
+      const outpost = new SentientOutpost(data, { locale: 'en', logger: console });
 
       outpost.id.should.equal('CrewBattleNode554:true');
       outpost.mission.node.should.equal('H-2 Cloud (Veil)');

--- a/test/unit/sentientOutpost.spec.js
+++ b/test/unit/sentientOutpost.spec.js
@@ -2,7 +2,7 @@ import * as chai from 'chai';
 import sinonChai from 'sinon-chai';
 
 import SentientOutpost from '../../lib/models/SentientOutpost.js';
-import Tmp from '../data/Tmp.json' assert { type: 'json' };
+import data from '../data/Tmp.js';
 
 chai.should();
 chai.use(sinonChai);
@@ -10,7 +10,7 @@ chai.use(sinonChai);
 describe('SentientOutpost', function () {
   describe('#constructor()', function () {
     it('should be able to handle some raw data', () => {
-      const outpost = new SentientOutpost(Tmp.Tmp, { locale: 'en', logger: console });
+      const outpost = new SentientOutpost(data.Tmp, { locale: 'en', logger: console });
 
       outpost.id.should.equal('CrewBattleNode554:true');
       outpost.mission.node.should.equal('H-2 Cloud (Veil)');


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Modified the `sfn` regex to match the entire `sfn` key-value since `Temp` now has Deep Archimedea data in it

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
