### PR TITLE
fix: default arbi data

### DIFF
--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -284,7 +284,17 @@ export default class WorldState {
     } = externalMissions);
 
     if (!this.arbitration || !Object.keys(this.arbitration).length) {
-      this.arbitration = undefined;
+      this.arbitration = {
+        node: 'SolNode000',
+        nodeKey: 'SolNode000',
+        activation: new Date(0),
+        expiry: new Date(8.64e15),
+        enemy: 'Tenno',
+        type: 'Unknown',
+        typeKey: 'Unknown',
+        archwing: false,
+        sharkwing: false,
+      };
     }
 
     /**


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
add default arbi data for [copium](https://canary.discord.com/channels/256087517353213954/1204130441440002068/1249818272975683634)

![image](https://github.com/WFCD/warframe-worldstate-parser/assets/7128721/6187a0bf-2050-4e45-947f-eb00622c0eca)


---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
