### PR TITLE
fix: deep archimedea can be undefined in worldstate

### DIFF
--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -367,8 +367,15 @@ export class WorldState {
 
     this.kinepage = new Kinepage(tmp.pgr, deps.locale);
 
-    const { activation, expiry } = this.nightwave.activeChallenges.filter((c) => !c.isDaily)[0];
-    this.deepArchimedea = new DeepArchimedea(activation, expiry, tmp.lqo27);
+    if (tmp.lqo27) {
+      const { activation, expiry } = this.nightwave.activeChallenges.filter((c) => !c.isDaily)[0];
+
+      /**
+       * The current Deep Archimedea missions and modifiers
+       * @type {DeepArchimedea}
+       */
+      this.deepArchimedea = new DeepArchimedea(activation, expiry, tmp.lqo27);
+    }
   }
 }
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Oh DE I get it but a warning would've been better. Anyways turns out Deep Archimedea data can be undefined

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
