### PR TITLE
fix: pass-through event tags

### DIFF
--- a/lib/models/WorldEvent.js
+++ b/lib/models/WorldEvent.js
@@ -269,6 +269,10 @@ export default class WorldEvent extends WorldstateObject {
       this.affiliatedWith = syndicate(data.JobAffiliationTag, locale);
     }
 
+    /**
+     * The event's tag
+     * @type {string}
+     */
     this.tag = data.Tag;
   }
 

--- a/lib/models/WorldEvent.js
+++ b/lib/models/WorldEvent.js
@@ -268,6 +268,8 @@ export default class WorldEvent extends WorldstateObject {
     if (data.JobAffiliationTag) {
       this.affiliatedWith = syndicate(data.JobAffiliationTag, locale);
     }
+
+    this.tag = data.Tag;
   }
 
   /**


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
pass-through event tags 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event details with an additional `tag` field, providing richer information about each event without affecting existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->