### PR TITLE
feat: parse calendar day into a timestamp

### DIFF
--- a/lib/models/Calendar.js
+++ b/lib/models/Calendar.js
@@ -45,7 +45,11 @@ export default class Calendar {
     this.expiry = parseDate(calendar.Expiry);
 
     this.days = Array.isArray(calendar.Days)
-      ? calendar.Days.filter(Boolean).map((d) => ({ ...d, events: d.events.map((e) => new DayEvent(e)) }))
+      ? calendar.Days.filter(Boolean).map((d) => ({
+          ...d,
+          date: this.getDate(d.day).toISOString(),
+          events: d.events.map((e) => new DayEvent(e)),
+        }))
       : [];
 
     this.season = translateSeason(calendar.Season);
@@ -55,5 +59,16 @@ export default class Calendar {
     this.version = calendar.Version;
 
     this.requirements = calendar.UpgradeAvaliabilityRequirements;
+  }
+
+  /**
+   * Converts number of day to a date in 1999 in UTC
+   * @param {number} day number of the day in a year
+   * @returns {Date} the date in 1999
+   */
+  getDate(day) {
+    const date = new Date(Date.UTC(1999));
+    date.setUTCDate(date.getDay() + day);
+    return date;
   }
 }

--- a/lib/models/Calendar.js
+++ b/lib/models/Calendar.js
@@ -68,7 +68,7 @@ export default class Calendar {
    */
   getDate(day) {
     const date = new Date(Date.UTC(1999));
-    date.setUTCDate(date.getDay() + day);
+    date.setUTCDate(date.getUTCDate() + day - 1);
     return date;
   }
 }

--- a/test/unit/calendar.spec.js
+++ b/test/unit/calendar.spec.js
@@ -16,7 +16,7 @@ describe('SentientOutpost', function () {
       calendar.days[0].events[0].challenge.description.should.equal('Kill 10 Eximus');
       calendar.days[1].events[0].upgrade.title.should.equal('Heavy Mags');
       calendar.days[4].events[0].reward.should.equal('Exilus Weapon Adapter Blueprint');
-      calendar.days[0].date.should.equal('1999-01-10T00:00:00.000Z');
+      calendar.days[0].date.should.equal('1999-01-06T00:00:00.000Z');
     });
     it('should throw TypeError when called with no argument or an invalid argument', function () {
       (() => {

--- a/test/unit/calendar.spec.js
+++ b/test/unit/calendar.spec.js
@@ -16,6 +16,7 @@ describe('SentientOutpost', function () {
       calendar.days[0].events[0].challenge.description.should.equal('Kill 10 Eximus');
       calendar.days[1].events[0].upgrade.title.should.equal('Heavy Mags');
       calendar.days[4].events[0].reward.should.equal('Exilus Weapon Adapter Blueprint');
+      calendar.days[0].date.should.equal('1999-01-10T00:00:00.000Z');
     });
     it('should throw TypeError when called with no argument or an invalid argument', function () {
       (() => {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Parse the calendar day into a timestamp date for the year 1999

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Calendar entries now include clearly formatted date information (displayed in UTC format), enhancing clarity and consistency for day events.
- **Tests**
	- Added verifications to ensure that the date presentations in the calendar display match expected formatting for a reliable user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->