### PR TITLE
fix: parse out `Deep Archimedea` when `lqo` suffix changes

### DIFF
--- a/lib/WorldState.js
+++ b/lib/WorldState.js
@@ -368,14 +368,15 @@ export class WorldState {
 
     this.kinepage = new Kinepage(tmp.pgr, deps.locale);
 
-    if (tmp.lqo27) {
+    const key = Object.keys(tmp).find((k) => k.startsWith('lqo'));
+    if (key) {
       const { activation, expiry } = this.nightwave.activeChallenges.filter((c) => !c.isDaily)[0];
 
       /**
        * The current Deep Archimedea missions and modifiers
        * @type {DeepArchimedea}
        */
-      this.deepArchimedea = new DeepArchimedea(activation, expiry, tmp.lqo27);
+      this.deepArchimedea = new DeepArchimedea(activation, expiry, tmp[key]);
     }
 
     this.calendar = parseArray(Calendar, data.KnownCalendarSeasons, deps);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Looks like DE is changing the digit suffix they were using for Deep Archimedea but at least the prefix stays the same

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal initialization process by adopting a dynamic lookup approach for configuration properties, enhancing the flexibility and reliability of state management.  
  - This update does not affect any publicly exposed functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->