### PR TITLE
fix: patch-notes in update regex

### DIFF
--- a/lib/models/News.js
+++ b/lib/models/News.js
@@ -5,7 +5,7 @@ import mdConfig from '../supporting/MarkdownSettings.js';
 
 import WorldstateObject from './WorldstateObject.js';
 
-const updateReg = /(update|hotfix)/i;
+const updateReg = /(update|hotfix|patch-notes)/i;
 const primeAccessReg = /(access)/i;
 const streamReg = /(devstream|prime-time|warframeinternational|stream)/i;
 const langString = /(\/Lotus\/Language\/)/i;


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #634 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of update-related news items by including "patch-notes" as a recognized keyword.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->