### PR TITLE
fix: midrath drifting in the middle of the day

### DIFF
--- a/lib/models/MidrathCycle.js
+++ b/lib/models/MidrathCycle.js
@@ -23,8 +23,9 @@ function getCurrentMidrathCycle() {
   const nightDuration = 16 * 60 * 1000; // 16 minutes in milliseconds
   const totalDuration = dayDuration + nightDuration;
 
-  const now = new Date();
-  const elapsedInCycle = (now.getTime() - 222000) % totalDuration;
+  const refPoint = Date.parse('2025-08-07T16:05:29Z');
+  const now = Date.now();
+  const elapsedInCycle = (now - refPoint) % totalDuration;
   const isDay = elapsedInCycle < dayDuration;
 
   let phase = {
@@ -41,7 +42,7 @@ function getCurrentMidrathCycle() {
     };
   }
 
-  const activation = new Date(now.getTime() - (phase.duration - phase.remaining));
+  const activation = new Date(now - (phase.duration - phase.remaining));
   const expiry = new Date(activation.getTime() + phase.duration);
   const timeLeft = timeDeltaToString(phase.remaining);
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Added a reference point to keep better track since it seems the previous drifted a bit throughout the day (real life day)

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the calculation method for the current Midrath cycle's elapsed time and activation time, ensuring more precise and consistent time tracking for day/night phases. No changes to visible features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->