### PR TITLE
fix: readd `rewardTypes` to invasions and alerts

### DIFF
--- a/lib/models/Alert.ts
+++ b/lib/models/Alert.ts
@@ -1,9 +1,9 @@
-import { fromNow, timeDeltaToString } from 'warframe-worldstate-data/utilities';
+import { fromNow, timeDeltaToString } from "warframe-worldstate-data/utilities";
 
-import type Dependency from '../supporting/Dependency';
-import Mission, { type RawMission } from './Mission';
-import type Reward from './Reward';
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
+import type Dependency from "../supporting/Dependency";
+import Mission, { type RawMission } from "./Mission";
+import type Reward from "./Reward";
+import WorldstateObject, { type BaseContentObject } from "./WorldstateObject";
 
 export interface RawAlert extends BaseContentObject {
   MissionInfo: RawMission;
@@ -21,11 +21,19 @@ export default class Alert extends WorldstateObject {
   mission: Mission;
 
   /**
+   * An array containing the types of all of the alert's rewards
+   */
+  rewardTypes: string[];
+
+  /**
    * A tag that DE occasionally provides, such as `LotusGift`
    */
   tag?: string;
 
-  constructor(data: RawAlert, { locale = 'en' }: Dependency = { locale: 'en' }) {
+  constructor(
+    data: RawAlert,
+    { locale = "en" }: Dependency = { locale: "en" },
+  ) {
     super(data);
 
     const deps = {
@@ -33,6 +41,9 @@ export default class Alert extends WorldstateObject {
     };
 
     this.mission = new Mission(data.MissionInfo, deps);
+    this.rewardTypes = this.reward?.getTypes()?.length
+      ? this.reward.getTypes()!
+      : ["credits"];
     this.tag = data.Tag || undefined;
   }
 
@@ -55,12 +66,5 @@ export default class Alert extends WorldstateObject {
    */
   get eta(): string {
     return timeDeltaToString(fromNow(this.expiry!));
-  }
-
-   /**
-   * An array containing the types of all of the alert's rewards
-   */
-  get rewardTypes(): string[] | undefined {
-    return this.reward?.getTypes()?.length ? this.reward.getTypes()! : ['credits']
   }
 }

--- a/lib/models/Alert.ts
+++ b/lib/models/Alert.ts
@@ -1,9 +1,9 @@
-import { fromNow, timeDeltaToString } from "warframe-worldstate-data/utilities";
+import { fromNow, timeDeltaToString } from 'warframe-worldstate-data/utilities';
 
-import type Dependency from "../supporting/Dependency";
-import Mission, { type RawMission } from "./Mission";
-import type Reward from "./Reward";
-import WorldstateObject, { type BaseContentObject } from "./WorldstateObject";
+import type Dependency from '../supporting/Dependency';
+import Mission, { type RawMission } from './Mission';
+import type Reward from './Reward';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
 
 export interface RawAlert extends BaseContentObject {
   MissionInfo: RawMission;
@@ -30,10 +30,7 @@ export default class Alert extends WorldstateObject {
    */
   tag?: string;
 
-  constructor(
-    data: RawAlert,
-    { locale = "en" }: Dependency = { locale: "en" },
-  ) {
+  constructor(data: RawAlert, { locale = 'en' }: Dependency = { locale: 'en' }) {
     super(data);
 
     const deps = {
@@ -41,9 +38,7 @@ export default class Alert extends WorldstateObject {
     };
 
     this.mission = new Mission(data.MissionInfo, deps);
-    this.rewardTypes = this.reward?.getTypes()?.length
-      ? this.reward.getTypes()!
-      : ["credits"];
+    this.rewardTypes = this.reward?.getTypes()?.length ? this.reward.getTypes()! : ['credits'];
     this.tag = data.Tag || undefined;
   }
 

--- a/lib/models/ConstructionProgress.ts
+++ b/lib/models/ConstructionProgress.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import WorldstateObject from './WorldstateObject.js';
+import WorldstateObject from './WorldstateObject';
 
 /**
  * Represents enemy construction progress

--- a/lib/models/DailyDeal.ts
+++ b/lib/models/DailyDeal.ts
@@ -5,8 +5,8 @@ import {
   timeDeltaToString,
 } from 'warframe-worldstate-data/utilities';
 
-import type Dependency from '../supporting/Dependency.js';
-import WorldstateObject from './WorldstateObject.js';
+import type Dependency from '../supporting/Dependency';
+import WorldstateObject from './WorldstateObject';
 
 export interface RawDailyDeal {
   StoreItem: string;

--- a/lib/models/DarkSector.ts
+++ b/lib/models/DarkSector.ts
@@ -1,9 +1,8 @@
-import { parseDate, languageString, type ContentTimestamp } from 'warframe-worldstate-data/utilities';
-
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
-import Mission, { type RawMission } from './Mission';
-import DarkSectorBattle, { type RawDarkSectorBattle } from './DarkSectorBattle';
+import { type ContentTimestamp, languageString, parseDate } from 'warframe-worldstate-data/utilities';
 import type Dependency from '../supporting/Dependency';
+import DarkSectorBattle, { type RawDarkSectorBattle } from './DarkSectorBattle';
+import Mission, { type RawMission } from './Mission';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
 
 interface DefenderInfo {
   CreditsTaxRate: number;

--- a/lib/models/GlobalUpgrade.ts
+++ b/lib/models/GlobalUpgrade.ts
@@ -7,8 +7,8 @@ import {
   upgrade
 } from 'warframe-worldstate-data/utilities';
 
-import type Dependency from '../supporting/Dependency.js';
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject.js';
+import type Dependency from '../supporting/Dependency';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
 
 export interface RawGlobalUpgrade extends BaseContentObject {
   Activation: ContentTimestamp;

--- a/lib/models/Invasion.ts
+++ b/lib/models/Invasion.ts
@@ -4,11 +4,13 @@ import {
   languageString,
   node,
   timeDeltaToString,
-  toNow
-} from 'warframe-worldstate-data/utilities';
-import type Dependency from '../supporting/Dependency.js';
-import Reward, { type RawReward } from './Reward.js';
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject.js';
+  toNow,
+} from "warframe-worldstate-data/utilities";
+import type Dependency from "../supporting/Dependency.js";
+import Reward, { type RawReward } from "./Reward.js";
+import WorldstateObject, {
+  type BaseContentObject,
+} from "./WorldstateObject.js";
 
 export interface RawInvasion extends BaseContentObject {
   Node: string;
@@ -99,11 +101,19 @@ export default class Invasion extends WorldstateObject {
   completed: boolean;
 
   /**
+   * An array containing the types of all of the invasions's rewards
+   */
+  rewardTypes: string[];
+
+  /**
    * @param   {object}             data            The invasion data
    * @param   {Dependency}         deps            The dependencies object
    * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(data: RawInvasion, { locale = 'en' }: Dependency = { locale: 'en' }) {
+  constructor(
+    data: RawInvasion,
+    { locale = "en" }: Dependency = { locale: "en" },
+  ) {
     super(data);
     const opts = { locale };
 
@@ -114,15 +124,19 @@ export default class Invasion extends WorldstateObject {
     this.desc = languageString(data.LocTag, locale);
 
     this.attacker = {
-      reward: Object.keys(data?.AttackerReward || {})?.length ? new Reward(data.AttackerReward, opts) : undefined,
+      reward: Object.keys(data?.AttackerReward || {})?.length
+        ? new Reward(data.AttackerReward, opts)
+        : undefined,
       faction: faction(data.DefenderMissionInfo.faction, locale),
-      factionKey: faction(data.DefenderMissionInfo.faction, 'en'),
+      factionKey: faction(data.DefenderMissionInfo.faction, "en"),
     };
 
     this.defender = {
-      reward: Object.keys(data?.DefenderReward || {})?.length ? new Reward(data.DefenderReward, opts) : undefined,
+      reward: Object.keys(data?.DefenderReward || {})?.length
+        ? new Reward(data.DefenderReward, opts)
+        : undefined,
       faction: faction(data.AttackerMissionInfo.faction, locale),
-      factionKey: faction(data.AttackerMissionInfo.faction, 'en'),
+      factionKey: faction(data.AttackerMissionInfo.faction, "en"),
     };
 
     this.vsInfestation = /infest/i.test(data.DefenderMissionInfo.faction);
@@ -131,9 +145,15 @@ export default class Invasion extends WorldstateObject {
 
     this.requiredRuns = data.Goal;
 
-    this.completion = (1 + data.Count / data.Goal) * (this.vsInfestation ? 100 : 50);
+    this.completion = (1 + data.Count / data.Goal) *
+      (this.vsInfestation ? 100 : 50);
 
     this.completed = data.Completed;
+
+    this.rewardTypes = [
+      ...(this.attacker.reward?.getTypes() ?? []),
+      ...(this.defender.reward?.getTypes() ?? []),
+    ];
   }
 
   /**
@@ -149,13 +169,6 @@ export default class Invasion extends WorldstateObject {
    */
   get eta(): string {
     return timeDeltaToString(this.getRemainingTime());
-  }
-
-  /**
-   * An array containing the types of all of the invasions's rewards
-   */
-  get rewardTypes(): string[] {
-    return [...(this.attacker.reward?.getTypes() ?? []), ...(this.defender.reward?.getTypes() ?? [])];
   }
 
   /**

--- a/lib/models/Invasion.ts
+++ b/lib/models/Invasion.ts
@@ -6,9 +6,9 @@ import {
   timeDeltaToString,
   toNow,
 } from 'warframe-worldstate-data/utilities';
-import type Dependency from '../supporting/Dependency.js';
-import Reward, { type RawReward } from './Reward.js';
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject.js';
+import type Dependency from '../supporting/Dependency';
+import Reward, { type RawReward } from './Reward';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
 
 export interface RawInvasion extends BaseContentObject {
   Node: string;

--- a/lib/models/Invasion.ts
+++ b/lib/models/Invasion.ts
@@ -5,12 +5,10 @@ import {
   node,
   timeDeltaToString,
   toNow,
-} from "warframe-worldstate-data/utilities";
-import type Dependency from "../supporting/Dependency.js";
-import Reward, { type RawReward } from "./Reward.js";
-import WorldstateObject, {
-  type BaseContentObject,
-} from "./WorldstateObject.js";
+} from 'warframe-worldstate-data/utilities';
+import type Dependency from '../supporting/Dependency.js';
+import Reward, { type RawReward } from './Reward.js';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject.js';
 
 export interface RawInvasion extends BaseContentObject {
   Node: string;
@@ -110,10 +108,7 @@ export default class Invasion extends WorldstateObject {
    * @param   {Dependency}         deps            The dependencies object
    * @param   {string}             deps.locale     Locale to use for translations
    */
-  constructor(
-    data: RawInvasion,
-    { locale = "en" }: Dependency = { locale: "en" },
-  ) {
+  constructor(data: RawInvasion, { locale = 'en' }: Dependency = { locale: 'en' }) {
     super(data);
     const opts = { locale };
 
@@ -124,19 +119,15 @@ export default class Invasion extends WorldstateObject {
     this.desc = languageString(data.LocTag, locale);
 
     this.attacker = {
-      reward: Object.keys(data?.AttackerReward || {})?.length
-        ? new Reward(data.AttackerReward, opts)
-        : undefined,
+      reward: Object.keys(data?.AttackerReward || {})?.length ? new Reward(data.AttackerReward, opts) : undefined,
       faction: faction(data.DefenderMissionInfo.faction, locale),
-      factionKey: faction(data.DefenderMissionInfo.faction, "en"),
+      factionKey: faction(data.DefenderMissionInfo.faction, 'en'),
     };
 
     this.defender = {
-      reward: Object.keys(data?.DefenderReward || {})?.length
-        ? new Reward(data.DefenderReward, opts)
-        : undefined,
+      reward: Object.keys(data?.DefenderReward || {})?.length ? new Reward(data.DefenderReward, opts) : undefined,
       faction: faction(data.AttackerMissionInfo.faction, locale),
-      factionKey: faction(data.AttackerMissionInfo.faction, "en"),
+      factionKey: faction(data.AttackerMissionInfo.faction, 'en'),
     };
 
     this.vsInfestation = /infest/i.test(data.DefenderMissionInfo.faction);
@@ -145,15 +136,11 @@ export default class Invasion extends WorldstateObject {
 
     this.requiredRuns = data.Goal;
 
-    this.completion = (1 + data.Count / data.Goal) *
-      (this.vsInfestation ? 100 : 50);
+    this.completion = (1 + data.Count / data.Goal) * (this.vsInfestation ? 100 : 50);
 
     this.completed = data.Completed;
 
-    this.rewardTypes = [
-      ...(this.attacker.reward?.getTypes() ?? []),
-      ...(this.defender.reward?.getTypes() ?? []),
-    ];
+    this.rewardTypes = [...(this.attacker.reward?.getTypes() ?? []), ...(this.defender.reward?.getTypes() ?? [])];
   }
 
   /**

--- a/lib/models/NightwaveChallenge.ts
+++ b/lib/models/NightwaveChallenge.ts
@@ -1,7 +1,6 @@
-import { languageDesc, languageString } from 'warframe-worldstate-data/utilities';
-
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject.js';
 import type { Locale } from 'warframe-worldstate-data';
+import { languageDesc, languageString } from 'warframe-worldstate-data/utilities';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
 
 const repBase = 1000;
 

--- a/lib/models/PersistentEnemy.ts
+++ b/lib/models/PersistentEnemy.ts
@@ -1,6 +1,6 @@
 import type { Locale } from 'warframe-worldstate-data';
 import { type ContentTimestamp, languageString, node, parseDate, region } from 'warframe-worldstate-data/utilities';
-import WorldstateObject, { type BaseContentObject } from './WorldstateObject.js';
+import WorldstateObject, { type BaseContentObject } from './WorldstateObject';
 
 export interface RawPersistentEnemy extends BaseContentObject {
   AgentType: string;

--- a/lib/supporting/RewardTypes.ts
+++ b/lib/supporting/RewardTypes.ts
@@ -1,5 +1,5 @@
-import { cdn, wfCdn } from './ImgCdn.js';
-import { auras, nightmare, resources } from './RewardData.js';
+import { cdn, wfCdn } from './ImgCdn';
+import { auras, nightmare, resources } from './RewardData';
 
 /**
  * An object describing a type of reward, including name, description,


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Readded `rewardTypes` on alerts and invasions because it's not so easy to generate outside the worldstate

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alerts and Invasions now expose explicit reward-type lists and default to a fallback when none are provided, improving reward visibility and consistency.
* **Chores**
  * Module import specifiers cleaned up across several model files for smoother module resolution and code hygiene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->