### PR TITLE
feat: add faceoffBonus state and QTCC goal/count

### DIFF
--- a/lib/Tmp.ts
+++ b/lib/Tmp.ts
@@ -10,8 +10,8 @@ export interface InitialTmp {
   fbst?: { a: number; e: number; n: number };
   lqo?: RawArchimedea;
   hqo?: RawArchimedea;
-  QTCCFloofCount: number;
-  QTCCFloofLimit: number;
+  QTCCFloofCount?: number;
+  QTCCFloofLimit?: number;
 }
 
 export class Tmp {
@@ -47,7 +47,7 @@ export class Tmp {
     }
 
     if (tmp.QTCCFloofCount) {
-      this.questToConquerCancer = { count: tmp.QTCCFloofCount, goal: tmp.QTCCFloofLimit };
+      this.questToConquerCancer = { count: tmp.QTCCFloofCount, goal: tmp.QTCCFloofLimit! };
     }
   }
 }

--- a/lib/Tmp.ts
+++ b/lib/Tmp.ts
@@ -20,7 +20,7 @@ export class Tmp {
   deepArchimedea?: Archimedea;
   temporalArchimedea?: Archimedea;
   faceoffBonus?: { activation: Date; expiry: Date; next: Date };
-  questToConquerCancer?: { count: number; next: number };
+  questToConquerCancer?: { count: number; goal: number };
 
   constructor(json: string, deps: Dependency = { locale: 'en' }) {
     const tmp: InitialTmp = JSON.parse(json);
@@ -47,7 +47,7 @@ export class Tmp {
     }
 
     if (tmp.QTCCFloofCount) {
-      this.questToConquerCancer = { count: tmp.QTCCFloofCount, next: tmp.QTCCFloofLimit };
+      this.questToConquerCancer = { count: tmp.QTCCFloofCount, goal: tmp.QTCCFloofLimit };
     }
   }
 }

--- a/lib/Tmp.ts
+++ b/lib/Tmp.ts
@@ -7,8 +7,11 @@ import type Dependency from './supporting/Dependency';
 export interface InitialTmp {
   sfn: number;
   pgr: { [k: string]: string | number };
+  fbst?: { a: number; e: number; n: number };
   lqo?: RawArchimedea;
   hqo?: RawArchimedea;
+  QTCCFloofCount: number;
+  QTCCFloofLimit: number;
 }
 
 export class Tmp {
@@ -16,6 +19,8 @@ export class Tmp {
   kinepage: Kinepage;
   deepArchimedea?: Archimedea;
   temporalArchimedea?: Archimedea;
+  faceoffBonus?: { activation: Date; expiry: Date; next: Date };
+  questToConquerCancer?: { count: number; next: number };
 
   constructor(json: string, deps: Dependency = { locale: 'en' }) {
     const tmp: InitialTmp = JSON.parse(json);
@@ -24,12 +29,25 @@ export class Tmp {
 
     this.kinepage = new Kinepage(tmp.pgr, deps.locale);
 
+    if (tmp.fbst) {
+      const toDate = (ms: number) => new Date(ms * 1000);
+      this.faceoffBonus = {
+        activation: toDate(tmp.fbst.a),
+        expiry: toDate(tmp.fbst.e),
+        next: toDate(tmp.fbst.n),
+      };
+    }
+
     if (tmp.lqo) {
       this.deepArchimedea = new Archimedea(tmp.lqo, deps.locale);
     }
 
     if (tmp.hqo) {
       this.temporalArchimedea = new Archimedea(tmp.hqo, deps.locale);
+    }
+
+    if (tmp.QTCCFloofCount) {
+      this.questToConquerCancer = { count: tmp.QTCCFloofCount, next: tmp.QTCCFloofLimit };
     }
   }
 }

--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -19,7 +19,6 @@ import GlobalUpgrade, { type RawGlobalUpgrade } from './models/GlobalUpgrade';
 import Invasion, { type RawInvasion } from './models/Invasion';
 import type Kinepage from './models/Kinepage';
 import Kuva from './models/Kuva';
-import MidrathCycle from './models/MidrathCycle';
 import News, { type RawNews } from './models/News';
 import Nightwave, { type RawNightwave } from './models/Nightwave';
 import PersistentEnemy, { type RawPersistentEnemy } from './models/PersistentEnemy';
@@ -353,7 +352,7 @@ export class WorldState {
   /**
    * Warfames annual Quest to Conquer Cancer donation count and next tier goal
    */
-  questToConquerCancer?: { count: number; next: number };
+  questToConquerCancer?: { count: number; goal: number };
 
   /**
    * Generates the worldstate json as a string into usable objects

--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -345,6 +345,16 @@ export class WorldState {
   calendar: Calendar;
 
   /**
+   * Faceoff bonus current state
+   */
+  faceoffBonus?: { activation: Date; expiry: Date; next: Date };
+
+  /**
+   * Warfames annual Quest to Conquer Cancer donation count and next tier goal
+   */
+  questToConquerCancer?: { count: number; next: number };
+
+  /**
    * Generates the worldstate json as a string into usable objects
    */
   static async build(json: string, deps: Dependency = defaultDeps): Promise<WorldState> {
@@ -477,6 +487,8 @@ export class WorldState {
       kinepage: this.kinepage,
       sentientOutposts: this.sentientOutposts,
       temporalArchimedea: this.temporalArchimedea,
+      faceoffBonus: this.faceoffBonus,
+      questToConquerCancer: this.questToConquerCancer,
     } = new Tmp(data.Tmp, deps));
   }
 }

--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -350,7 +350,7 @@ export class WorldState {
   faceoffBonus?: { activation: Date; expiry: Date; next: Date };
 
   /**
-   * Warfames annual Quest to Conquer Cancer donation count and next tier goal
+   * Warframe's annual Quest to Conquer Cancer donation count and next tier goal  
    */
   questToConquerCancer?: { count: number; goal: number };
 

--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -266,8 +266,9 @@ export class WorldState {
 
   /**
    * Midrath cycle (soulframe)
+   * Game seems to desync while you play and appearntly it changes between updates.
    */
-  midrathCycle: MidrathCycle;
+  // midrathCycle: MidrathCycle;
 
   /**
    * Weekly challenges
@@ -439,7 +440,7 @@ export class WorldState {
 
     this.zarimanCycle = new ZarimanCycle(bountyEnd);
 
-    this.midrathCycle = new MidrathCycle();
+    // this.midrathCycle = new MidrathCycle();
 
     this.weeklyChallenges = data.WeeklyChallenges ? new WeeklyChallenge(data.WeeklyChallenges) : undefined;
 
@@ -473,7 +474,7 @@ export class WorldState {
 
     this.steelPath = new SteelPathOffering(deps);
 
-    [this.vaultTrader] = parseArray(VoidTrader, data.PrimeVaultTraders, {...deps, character: 'Varzia'});
+    [this.vaultTrader] = parseArray(VoidTrader, data.PrimeVaultTraders, { ...deps, character: 'Varzia' });
 
     [this.archonHunt] = parseArray(Sortie, data.LiteSorties, deps);
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- Add faceoff bonus activation and expiry
- Add QTCC current and goal count
- turned off midrath timer (see below)

TL'DR The game has a buggy timer, it may drift so I'm not even sure I have it right, add to it that DE may actually change the time (night used to be 20 mins)

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds a Faceoff Bonus indicator showing activation, expiry, and next timings.
  - Displays Quest to Conquer Cancer progress with current count and goal.

- Refactor
  - Deactivates the legacy Midrath Cycle indicator from the runtime experience.

- Chores
  - Extends saved state so Faceoff Bonus and Quest progress persist across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->