### PR TITLE
fix: log bounty fetch failures

### DIFF
--- a/lib/models/SyndicateJob.ts
+++ b/lib/models/SyndicateJob.ts
@@ -65,7 +65,8 @@ interface BountyReward {
 const getBountyRewards = async (
   i18n: string,
   raw: RawSyndicateJob,
-  isVault?: boolean
+  isVault?: boolean,
+  logger: Dependency['logger'] = console
 ): Promise<(string | BountyReward)[]> => {
   let location: string | undefined;
   let locationWRot: string | undefined;
@@ -79,7 +80,10 @@ const getBountyRewards = async (
   const url = `${apiBase}/drops/search/${encodeURIComponent(location!)}?grouped_by=location`;
   const reply: Record<string, { rewards: BountyReward[] }> = await fetch(url)
     .then((res) => res.json())
-    .catch(() => {}); // swallow errors
+    .catch((error) => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger?.debug(`Failed to fetch bounty rewards for ${location}: ${errorMessage}`);
+    });
   const pool = reply?.[locationWRot];
   if (!pool) {
     return ['Pattern Mismatch. Results inaccurate.'];
@@ -195,7 +199,7 @@ export class SyndicateJob extends WorldStateObject {
     deps: Dependency
   ): Promise<SyndicateJob> {
     const job = new SyndicateJob(data, expiry, deps);
-    const rewards = await getBountyRewards(data.rewards, data, data.isVault);
+    const rewards = await getBountyRewards(data.rewards, data, data.isVault, deps.logger);
     if (typeof rewards[0] === 'string') {
       job.rewardPool = rewards as string[];
     } else {

--- a/lib/models/SyndicateJob.ts
+++ b/lib/models/SyndicateJob.ts
@@ -81,8 +81,11 @@ const getBountyRewards = async (
   const reply: Record<string, { rewards: BountyReward[] }> = await fetch(url)
     .then((res) => res.json())
     .catch((error) => {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger?.debug(`Failed to fetch bounty rewards for ${location}: ${errorMessage}`);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger?.debug(
+        `Failed to fetch bounty rewards for ${location}: ${errorMessage}`
+      );
     });
   const pool = reply?.[locationWRot];
   if (!pool) {
@@ -199,7 +202,12 @@ export class SyndicateJob extends WorldStateObject {
     deps: Dependency
   ): Promise<SyndicateJob> {
     const job = new SyndicateJob(data, expiry, deps);
-    const rewards = await getBountyRewards(data.rewards, data, data.isVault, deps.logger);
+    const rewards = await getBountyRewards(
+      data.rewards,
+      data,
+      data.isVault,
+      deps.logger
+    );
     if (typeof rewards[0] === 'string') {
       job.rewardPool = rewards as string[];
     } else {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
references #821

Technically this does not fix anything, just helps provide more insight into what's going wrong with bounty rewards in the world state.

---

### Reproduction steps
1. Fetch `https://api.warframestat.us/pc/`
2. Fetch `https://api.warframe.com/cdn/worldState.php`
3. Observe that some bounties of **JSON of 1** have the reward `['Pattern Mismatch. Results inaccurate.']`.
4. Parse **JSON of 2** locally. Observe that no bounty has the error reward.
5. This clearly indicates that something is going wrong when fetching the bounty rewards on the remote system.

---

### Evidence/screenshot/link to line

This only adds a debug statement to log errors instead of swallowing them, to help check what the actual issue is.

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes** (oops)
- Is is a bug fix, feature request, or enhancement? **Help for Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bounty reward fetch failures are no longer silently ignored — errors are now emitted to debug logs to aid troubleshooting.
  * No changes to user-facing outcomes; improved diagnostics provide better visibility into fetch issues without altering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WFCD/warframe-worldstate-parser/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->