### PR TITLE
fix: `EndlessXpChoices` is now `EndlessXpSchedule`

### DIFF
--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -627,7 +627,10 @@ export class WorldState {
 
     [this.archonHunt] = parseArray(Sortie, data.LiteSorties, deps);
 
-    const choices = parseArray(DuviriChoice, data.EndlessXpSchedule[0].CategoryChoices, deps);
+    const rawChoices = safeArray<RawChoice>(
+      data.EndlessXpSchedule?.[0]?.CategoryChoices
+    );
+    const choices = parseArray(DuviriChoice, rawChoices, deps);
     this.duviriCycle = new DuviriCycle(choices);
 
     [this.calendar] = parseArray(Calendar, data.KnownCalendarSeasons, deps);

--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -180,7 +180,7 @@ export interface InitialWorldState {
   ProjectPct: number[];
   SeasonInfo: RawNightwave;
   PrimeVaultTraders: RawVoidTrader[];
-  EndlessXpChoices: RawChoice[];
+  EndlessXpSchedule: Array<{ CategoryChoices: RawChoice[] }>;
   KnownCalendarSeasons: RawCalender[];
   Conquests: RawArchimedea[];
   Tmp: string;
@@ -627,7 +627,7 @@ export class WorldState {
 
     [this.archonHunt] = parseArray(Sortie, data.LiteSorties, deps);
 
-    const choices = parseArray(DuviriChoice, data.EndlessXpChoices, deps);
+    const choices = parseArray(DuviriChoice, data.EndlessXpSchedule[0].CategoryChoices, deps);
     this.duviriCycle = new DuviriCycle(choices);
 
     [this.calendar] = parseArray(Calendar, data.KnownCalendarSeasons, deps);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
New warframe update brought a couple of changes, here is just a quick patch


[logs.txt](https://github.com/user-attachments/files/29090987/logs.txt)

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Duviri “Endless XP” data handling to use the new schedule/category format, improving support for structured and optionally missing schedule data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->