### PR TITLE
fix: set `GlobalUpgrade.expiry` from `raw.ExpiryDate`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
   "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
   "files": {
     "ignoreUnknown": true,

--- a/lib/models/GlobalUpgrade.ts
+++ b/lib/models/GlobalUpgrade.ts
@@ -15,7 +15,8 @@ import { type BaseContentObject, WorldStateObject } from './WorldStateObject';
 
 export interface RawGlobalUpgrade extends BaseContentObject {
   Activation: ContentTimestamp;
-  ExpiryDate: ContentTimestamp;
+  Expiry?: ContentTimestamp;
+  ExpiryDate?: ContentTimestamp;
   UpgradeType: string;
   OperationType: string;
   Value: number;
@@ -60,7 +61,7 @@ export class GlobalUpgrade extends WorldStateObject {
   ) {
     super(data);
 
-    this.expiry = parseDate(data.ExpiryDate);
+    this.expiry = parseDate(data.Expiry ?? data.ExpiryDate);
     this.upgrade = upgrade(data.UpgradeType, locale);
     this.operation = operation(data.OperationType, locale);
     this.operationSymbol = operationSymbol(data.OperationType, locale);

--- a/lib/models/GlobalUpgrade.ts
+++ b/lib/models/GlobalUpgrade.ts
@@ -4,6 +4,7 @@ import {
   fromNow,
   operation,
   operationSymbol,
+  parseDate,
   timeDeltaToString,
   upgrade,
 } from 'warframe-worldstate-data/utilities';
@@ -14,7 +15,7 @@ import { type BaseContentObject, WorldStateObject } from './WorldStateObject';
 
 export interface RawGlobalUpgrade extends BaseContentObject {
   Activation: ContentTimestamp;
-  Expiry: ContentTimestamp;
+  ExpiryDate: ContentTimestamp;
   UpgradeType: string;
   OperationType: string;
   Value: number;
@@ -59,6 +60,7 @@ export class GlobalUpgrade extends WorldStateObject {
   ) {
     super(data);
 
+    this.expiry = parseDate(data.ExpiryDate);
     this.upgrade = upgrade(data.UpgradeType, locale);
     this.operation = operation(data.OperationType, locale);
     this.operationSymbol = operationSymbol(data.OperationType, locale);

--- a/test/data/GlobalUpgrade.json
+++ b/test/data/GlobalUpgrade.json
@@ -1,0 +1,10 @@
+{
+  "_id": { "$oid": "6a1066e4b633098fd906764b" },
+  "Activation": { "$date": { "$numberLong": "1787238000000" } },
+  "ExpiryDate": { "$date": { "$numberLong": "1787583600000" } },
+  "UpgradeType": "GAMEPLAY_KILL_XP_AMOUNT",
+  "OperationType": "MULTIPLY",
+  "Value": 2,
+  "LocalizeTag": "",
+  "LocalizeDescTag": ""
+}

--- a/test/unit/globalUpgrade.ts
+++ b/test/unit/globalUpgrade.ts
@@ -1,0 +1,20 @@
+import * as chai from 'chai';
+
+import { GlobalUpgrade, type RawGlobalUpgrade } from '@/models';
+import data from '@/data/GlobalUpgrade.json' with { type: 'json' };
+
+const expect = chai.expect;
+
+describe('GlobalUpgrade', function () {
+  describe('#constructor()', function () {
+    it('should be able to handle raw data', function () {
+      const globalUpgrade = new GlobalUpgrade(data);
+      expect(globalUpgrade.expiry).to.not.equal(undefined);
+    });
+    it('should throw TypeError when called with no arguments or an invalid argument', function () {
+      expect(() => {
+        new GlobalUpgrade(undefined as unknown as RawGlobalUpgrade);
+      }).to.throw(TypeError);
+    });
+  });
+});


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
DE emites global upgrade expiry under `ExpiryDate` instead of `Expiry`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
