### PR TITLE
feat: parse weekly Descendia rotation from Descents

### DIFF
--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -23,6 +23,7 @@ import {
   ConstructionProgress,
   DailyDeal,
   DarkSector,
+  Descendia,
   DuviriCycle,
   EarthCycle,
   Fissure,
@@ -41,6 +42,7 @@ import {
   type RawChallenge,
   type RawDailyDeal,
   type RawDarkSector,
+  type RawDescent,
   type RawFissure,
   type RawFlashSale,
   type RawGlobalUpgrade,
@@ -185,6 +187,7 @@ export interface InitialWorldState {
   EndlessXpSchedule: Array<{ CategoryChoices: RawChoice[] }>;
   KnownCalendarSeasons: RawCalender[];
   Conquests: RawArchimedea[];
+  Descents?: RawDescent[];
   WeeklyVaultBonusRewards: WeeklyVaultBonusReward[];
   Tmp: string;
 }
@@ -460,6 +463,14 @@ export class WorldState {
   archimedeas: Archimedea[];
 
   /**
+   * Current week's Descendia rotation (first Descents entry)
+   */
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => Descendia)
+  descendia?: Descendia;
+
+  /**
    * The current calendar for 1999
    */
   @ValidateNested()
@@ -646,6 +657,8 @@ export class WorldState {
     [this.calendar] = parseArray(Calendar, data.KnownCalendarSeasons, deps);
 
     this.archimedeas = parseArray(Archimedea, data.Conquests, deps);
+
+    this.descendia = parseArray(Descendia, data.Descents, deps)[0];
 
     ({
       kinepage: this.kinepage,

--- a/lib/WorldState.ts
+++ b/lib/WorldState.ts
@@ -658,7 +658,11 @@ export class WorldState {
 
     this.archimedeas = parseArray(Archimedea, data.Conquests, deps);
 
-    this.descendia = parseArray(Descendia, data.Descents, deps)[0];
+    this.descendia = parseArray(
+      Descendia,
+      safeArray<RawDescent>(data.Descents),
+      deps
+    )[0];
 
     ({
       kinepage: this.kinepage,

--- a/lib/models/Descendia.ts
+++ b/lib/models/Descendia.ts
@@ -9,7 +9,7 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { languageString } from 'warframe-worldstate-data/utilities';
+import { insist, languageString } from 'warframe-worldstate-data/utilities';
 
 import type { Dependency } from '@/supporting';
 
@@ -169,6 +169,7 @@ export class Descendia extends WorldStateObject {
    * @param deps.locale Locale to use for translations
    */
   constructor(data: RawDescent, { locale }: Dependency = { locale: 'en' }) {
+    insist({ ...data }, 'RandSeed', 'Challenges');
     super(data);
 
     this.id = createHash('md5')
@@ -176,7 +177,7 @@ export class Descendia extends WorldStateObject {
       .digest('hex');
 
     this.seed = data.RandSeed;
-    this.challenges = (data.Challenges ?? []).map(
+    this.challenges = data.Challenges.map(
       (challenge) => new DescendiaChallenge(challenge, { locale })
     );
   }

--- a/lib/models/Descendia.ts
+++ b/lib/models/Descendia.ts
@@ -1,0 +1,183 @@
+import { createHash } from 'node:crypto';
+
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsInt,
+  IsNumber,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { languageString } from 'warframe-worldstate-data/utilities';
+
+import type { Dependency } from '@/supporting';
+
+import { type BaseContentObject, WorldStateObject } from './WorldStateObject';
+
+export interface RawDescentChallenge {
+  Index: number;
+  Type: string;
+  Challenge: string;
+  Level: string;
+  Specs: string[];
+  Auras: string[];
+}
+
+export interface RawDescent extends BaseContentObject {
+  RandSeed: number;
+  Challenges: RawDescentChallenge[];
+}
+
+/**
+ * A keyed Descendia path that keeps the raw uniqueName
+ */
+export class DescendiaKeyedItem {
+  /**
+   * Raw uniqueName path
+   */
+  @IsString()
+  uniqueName: string;
+
+  /**
+   * Localized name
+   */
+  @IsString()
+  name: string;
+
+  constructor(uniqueName: string, locale: string) {
+    this.uniqueName = uniqueName;
+    this.name = languageString(uniqueName, locale);
+  }
+}
+
+/**
+ * A single Infernum floor in The Descendia
+ */
+export class DescendiaChallenge {
+  /**
+   * Floor number (1-21)
+   */
+  @IsInt()
+  @Min(1)
+  index: number;
+
+  /**
+   * Localized mission objective
+   */
+  @IsString()
+  type: string;
+
+  /**
+   * Raw mission objective key (e.g. DT_EXTERMINATE)
+   */
+  @IsString()
+  typeKey: string;
+
+  /**
+   * Localized floor content / penance
+   */
+  @IsString()
+  challenge: string;
+
+  /**
+   * Raw floor content key (e.g. JadeGuardian, Wisp, Devil)
+   */
+  @IsString()
+  challengeKey: string;
+
+  /**
+   * Localized level / map name
+   */
+  @IsString()
+  level: string;
+
+  /**
+   * Raw level uniqueName path
+   */
+  @IsString()
+  levelUniqueName: string;
+
+  /**
+   * Enemy mix specs
+   */
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DescendiaKeyedItem)
+  specs: DescendiaKeyedItem[];
+
+  /**
+   * Penance auras
+   */
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DescendiaKeyedItem)
+  auras: DescendiaKeyedItem[];
+
+  /**
+   * @param data        Raw challenge data
+   * @param deps        The dependencies object
+   * @param deps.locale Locale to use for translations
+   */
+  constructor(
+    data: RawDescentChallenge,
+    { locale = 'en' }: Dependency = { locale: 'en' }
+  ) {
+    this.index = data.Index;
+    this.type = languageString(data.Type, locale);
+    this.typeKey = data.Type;
+    this.challenge = languageString(data.Challenge, locale);
+    this.challengeKey = data.Challenge;
+    this.level = languageString(data.Level, locale);
+    this.levelUniqueName = data.Level;
+    this.specs = (data.Specs ?? []).map(
+      (spec) => new DescendiaKeyedItem(spec, locale)
+    );
+    this.auras = (data.Auras ?? []).map(
+      (aura) => new DescendiaKeyedItem(aura, locale)
+    );
+  }
+}
+
+/**
+ * Weekly Descendia rotation (The Dark Refractory)
+ */
+export class Descendia extends WorldStateObject {
+  /**
+   * MD5 generated ID
+   */
+  @IsString()
+  id: string;
+
+  /**
+   * Seed used to generate this week's floors
+   */
+  @IsNumber()
+  seed: number;
+
+  /**
+   * All 21 Infernum floors
+   */
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DescendiaChallenge)
+  challenges: DescendiaChallenge[];
+
+  /**
+   * @param data        Raw descent data
+   * @param deps        The dependencies object
+   * @param deps.locale Locale to use for translations
+   */
+  constructor(data: RawDescent, { locale }: Dependency = { locale: 'en' }) {
+    super(data);
+
+    this.id = createHash('md5')
+      .update(JSON.stringify(data), 'utf8')
+      .digest('hex');
+
+    this.seed = data.RandSeed;
+    this.challenges = (data.Challenges ?? []).map(
+      (challenge) => new DescendiaChallenge(challenge, { locale })
+    );
+  }
+}

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -10,6 +10,7 @@ export * from './ConstructionProgress';
 export * from './DailyDeal';
 export * from './DarkSector';
 export * from './DarkSectorBattle';
+export * from './Descendia';
 export * from './DuviriCycle';
 export * from './EarthCycle';
 export * from './Fissure';

--- a/test/data/Descendia.json
+++ b/test/data/Descendia.json
@@ -1,0 +1,241 @@
+{
+  "Activation": {
+    "$date": {
+      "$numberLong": "1787529600000"
+    }
+  },
+  "Expiry": {
+    "$date": {
+      "$numberLong": "1788134400000"
+    }
+  },
+  "RandSeed": 2512983008,
+  "Challenges": [
+    {
+      "Index": 1,
+      "Type": "DT_EXTERMINATE",
+      "Challenge": "JadeGuardian",
+      "Level": "/Lotus/Levels/DevilTower/ArenaPeach.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHGrineerSealabExterminate"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/JadeGuardianEnhancementAura"
+      ]
+    },
+    {
+      "Index": 2,
+      "Type": "DT_ALCHEMY",
+      "Challenge": "UnseenFoes",
+      "Level": "/Lotus/Levels/DevilTower/ArenaEggplant.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHGrineerZarimanExterminate"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/CoHUnseenFoesAura"
+      ]
+    },
+    {
+      "Index": 3,
+      "Type": "DT_DEFENSE",
+      "Challenge": "SecuritySpin",
+      "Level": "/Lotus/Levels/DevilTower/ArenaMango.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHGrineerNightwatchExterminate"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/CoHSecuritySpinAura"
+      ]
+    },
+    {
+      "Index": 4,
+      "Type": "DT_SABOTAGE_HIVE",
+      "Challenge": "ShockingLeech",
+      "Level": "/Lotus/Levels/DevilTower/ArenaPeach.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/CorpusGrineerMix"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/ShockingLeechEnhancementAura"
+      ]
+    },
+    {
+      "Index": 5,
+      "Type": "DT_PRESURE_GAUGE",
+      "Challenge": "FreezeInShoot",
+      "Level": "/Lotus/Levels/DevilTower/ArenaCoconut.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Duviri/Arena/DuviriMITWSurvivalSpecA"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/FreezeNShootEnhancementAura"
+      ]
+    },
+    {
+      "Index": 6,
+      "Type": "DT_COLLECTION",
+      "Challenge": "NC_NarmerPhobia",
+      "Level": "/Lotus/Levels/DevilTower/ArenaWaffle.level",
+      "Specs": [],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/CoHNarmerPhobiaAura"
+      ]
+    },
+    {
+      "Index": 7,
+      "Type": "DT_PROTOFRAME",
+      "Challenge": "Wisp",
+      "Level": "/Lotus/Levels/DevilTower/ProtoframeRoomWisp.level",
+      "Specs": [],
+      "Auras": []
+    },
+    {
+      "Index": 8,
+      "Type": "DT_NETRACELLS",
+      "Challenge": "RocketsOnly",
+      "Level": "/Lotus/Levels/DevilTower/ArenaMango.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHForestGrineerFairy"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/RocketSpawnAura",
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/RocketsOnlyAura"
+      ]
+    },
+    {
+      "Index": 9,
+      "Type": "DT_MIMICS",
+      "Challenge": "BasicMimics",
+      "Level": "/Lotus/Levels/DevilTower/ArenaMango.level",
+      "Specs": [],
+      "Auras": []
+    },
+    {
+      "Index": 10,
+      "Type": "DT_SABOTAGE_DEFENSE",
+      "Challenge": "MineField",
+      "Level": "/Lotus/Levels/DevilTower/ArenaCherry.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/VaniaExterminateTechrotSpec"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/CoHMineFieldAura"
+      ]
+    },
+    {
+      "Index": 11,
+      "Type": "DT_SHRINE_DEFENSE",
+      "Challenge": "GlassMaker",
+      "Level": "/Lotus/Levels/DevilTower/ArenaMelon.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/CorpusExterminateRobots"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/GlassMakerAura"
+      ]
+    },
+    {
+      "Index": 12,
+      "Type": "DT_EXCAVATION",
+      "Challenge": "ToxicFire",
+      "Level": "/Lotus/Levels/DevilTower/ArenaWaffle.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/CorpusGrineerInvasionHard"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/ToxicFireEnhancementAura"
+      ]
+    },
+    {
+      "Index": 13,
+      "Type": "DT_EXTERMINATE",
+      "Challenge": "NecroMechWeakpoints",
+      "Level": "/Lotus/Levels/DevilTower/ArenaGrape.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHNecroMechSpec"
+      ],
+      "Auras": [
+        "/Lotus/Types/Gameplay/EntratiLab/LabConquest/GenericFortifiedFoesWeakpointAura"
+      ]
+    },
+    {
+      "Index": 14,
+      "Type": "DT_PROTOFRAME",
+      "Challenge": "Harrow",
+      "Level": "/Lotus/Levels/DevilTower/ProtoframeRoomHarrow.level",
+      "Specs": [],
+      "Auras": []
+    },
+    {
+      "Index": 15,
+      "Type": "DT_BOSS",
+      "Challenge": "JohnProdman",
+      "Level": "/Lotus/Levels/DevilTower/ArenaWaffle.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/CorpusVenusResearchFacility"
+      ],
+      "Auras": []
+    },
+    {
+      "Index": 16,
+      "Type": "DT_COLLECTION",
+      "Challenge": "NC_SecuritySpin",
+      "Level": "/Lotus/Levels/DevilTower/ArenaEggplant.level",
+      "Specs": [],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/CoHSecuritySpinAura"
+      ]
+    },
+    {
+      "Index": 17,
+      "Type": "DT_LOOT_CREATURES",
+      "Challenge": "BasicLootCreatures",
+      "Level": "/Lotus/Levels/DevilTower/ArenaEggplant.level",
+      "Specs": [],
+      "Auras": []
+    },
+    {
+      "Index": 18,
+      "Type": "DT_ALCHEMY",
+      "Challenge": "Manics",
+      "Level": "/Lotus/Levels/DevilTower/ArenaMelon.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHManicSpec"
+      ],
+      "Auras": []
+    },
+    {
+      "Index": 19,
+      "Type": "DT_NETRACELLS",
+      "Challenge": "GrenadesOnly",
+      "Level": "/Lotus/Levels/DevilTower/ArenaCoconut.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/OrokinExterminateB"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/GrenadeSpawnAura",
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/GrenadesOnlyAura"
+      ]
+    },
+    {
+      "Index": 20,
+      "Type": "DT_DEFENSE",
+      "Challenge": "FieryTrail",
+      "Level": "/Lotus/Levels/DevilTower/ArenaWaffle.level",
+      "Specs": [
+        "/Lotus/Types/Game/EnemySpecs/Tau/CoHPNWNarmerCorpusGasExterminate"
+      ],
+      "Auras": [
+        "/Lotus/Types/Scripts/Tau/CoH/Complications/FieryTrailAura"
+      ]
+    },
+    {
+      "Index": 21,
+      "Type": "DT_PROTOFRAME",
+      "Challenge": "Devil",
+      "Level": "/Lotus/Levels/DevilTower/BossArenaUriel.level",
+      "Specs": [],
+      "Auras": []
+    }
+  ]
+}

--- a/test/unit/descendia.spec.ts
+++ b/test/unit/descendia.spec.ts
@@ -14,6 +14,12 @@ describe('Descendia', function () {
       expect(() => {
         new Descendia({} as unknown as RawDescent);
       }).to.throw(TypeError);
+      expect(() => {
+        new Descendia({
+          Activation: { $date: { $numberLong: '1787529600000' } },
+          Expiry: { $date: { $numberLong: '1788134400000' } },
+        } as unknown as RawDescent);
+      }).to.throw(TypeError);
     });
 
     it('should parse live-shaped descent data', () => {

--- a/test/unit/descendia.spec.ts
+++ b/test/unit/descendia.spec.ts
@@ -1,0 +1,39 @@
+import * as chai from 'chai';
+
+import { Descendia, type RawDescent } from '@/models';
+import data from '@/data/Descendia.json' with { type: 'json' };
+
+const expect = chai.expect;
+
+describe('Descendia', function () {
+  describe('#constructor()', function () {
+    it('should throw TypeError when called with no argument or an invalid argument', function () {
+      expect(() => {
+        new Descendia(undefined as unknown as RawDescent);
+      }).to.throw(TypeError);
+      expect(() => {
+        new Descendia({} as unknown as RawDescent);
+      }).to.throw(TypeError);
+    });
+
+    it('should parse live-shaped descent data', () => {
+      const descendia = new Descendia(data as RawDescent);
+
+      expect(descendia.seed).to.equal(data.RandSeed);
+      expect(descendia.challenges).to.have.length(21);
+      expect(descendia.challenges[0].index).to.equal(1);
+      expect(descendia.challenges[0].typeKey).to.equal(data.Challenges[0].Type);
+      expect(descendia.challenges[0].challengeKey).to.equal(
+        data.Challenges[0].Challenge
+      );
+      expect(descendia.challenges[0].levelUniqueName).to.equal(
+        data.Challenges[0].Level
+      );
+      expect(descendia.challenges[0].auras[0].uniqueName).to.equal(
+        data.Challenges[0].Auras[0]
+      );
+      expect(descendia.challenges[20].challengeKey).to.equal('Devil');
+      expect(descendia.challenges[20].typeKey).to.equal('DT_PROTOFRAME');
+    });
+  });
+});


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Expose WorldState.descendia from the first Descents entry with floor keys and uniqueNames.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Descendia world-state data.
  * Exposed Descendia details including rotation ID, seed, challenges, levels, localized names, enemy specifications, and auras.
  * Added validation for challenge data and support for weekly rotation configurations.

* **Tests**
  * Added coverage for parsing Descendia data and validating required input.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->