### PR TITLE
fix(#943): keep item uniqueNames for localization

### DIFF
--- a/lib/models/Calendar.ts
+++ b/lib/models/Calendar.ts
@@ -32,6 +32,10 @@ export class DayEvent {
   challenge?: { title: string; description: string };
   upgrade?: { title: string; description: string };
   reward?: string;
+  /**
+   * Raw uniqueName path for the reward item
+   */
+  uniqueName?: string;
   dialogueName?: string;
   dialogueConvo?: string;
 
@@ -46,7 +50,10 @@ export class DayEvent {
 
     if (event.upgrade) this.upgrade = this.eventDescription(event.upgrade);
 
-    if (event.reward) this.reward = languageString(event.reward);
+    if (event.reward) {
+      this.reward = languageString(event.reward);
+      this.uniqueName = event.reward;
+    }
 
     if (event.type === 'CET_PLOT') {
       this.dialogueName = event.dialogueName;

--- a/lib/models/FlashSale.ts
+++ b/lib/models/FlashSale.ts
@@ -33,6 +33,12 @@ export class FlashSale extends WorldStateObject {
   item: string;
 
   /**
+   * The uniqueName for the item on sale
+   */
+  @IsString()
+  uniqueName: string;
+
+  /**
    * The item's discount percentage
    */
   @IsNumber()
@@ -89,6 +95,8 @@ export class FlashSale extends WorldStateObject {
     super({ Activation: data.StartDate, Expiry: data.EndDate });
 
     this.item = languageString(data.TypeName, locale);
+
+    this.uniqueName = data.TypeName;
 
     this.discount = data.Discount;
 

--- a/lib/models/Mission.ts
+++ b/lib/models/Mission.ts
@@ -166,6 +166,13 @@ export class Mission {
   requiredItems: string[];
 
   /**
+   * Raw uniqueName paths for items required to enter the mission
+   */
+  @IsArray()
+  @IsString({ each: true })
+  requiredItemUniqueNames: string[];
+
+  /**
    * Whether or not the required items are consumed
    */
   @IsOptional()
@@ -205,6 +212,12 @@ export class Mission {
    */
   @IsString()
   exclusiveWeapon: string;
+
+  /**
+   * Raw uniqueName path for the exclusive weapon
+   */
+  @IsString()
+  exclusiveWeaponUniqueName: string;
 
   /**
    * @param data   The mission data
@@ -255,7 +268,8 @@ export class Mission {
       languageString(spawner, locale)
     );
 
-    this.requiredItems = (data.requiredItems || []).map((reqItem) =>
+    this.requiredItemUniqueNames = data.requiredItems || [];
+    this.requiredItems = this.requiredItemUniqueNames.map((reqItem) =>
       languageString(reqItem, locale)
     );
 
@@ -273,6 +287,7 @@ export class Mission {
       languageString(aura, locale)
     );
 
+    this.exclusiveWeaponUniqueName = data.exclusiveWeapon;
     this.exclusiveWeapon = languageString(data.exclusiveWeapon, locale);
   }
 }

--- a/lib/models/Reward.ts
+++ b/lib/models/Reward.ts
@@ -27,21 +27,44 @@ export interface RawReward {
 }
 
 /**
+ * A counted reward item, including uncounted `items` folded in at count 1
+ */
+export interface CountedItem {
+  /**
+   * Raw item uniqueName path
+   */
+  uniqueName: string;
+  /**
+   * Localized item name
+   */
+  type: string;
+  /**
+   * English item name
+   */
+  key: string;
+  /**
+   * Quantity rewarded
+   */
+  count: number;
+}
+
+/**
  * Represents a mission reward
  */
 export class Reward {
   /**
    * The items being rewarded
+   * @deprecated Use {@link Reward.countedItems} instead
    */
   @IsArray()
   @IsString({ each: true })
   items: string[];
 
   /**
-   * The counted items being rewarded
+   * All rewarded items, including former uncounted `items` at count 1
    */
   @IsArray()
-  countedItems: { type: string; key: string; count: number }[];
+  countedItems: CountedItem[];
 
   /**
    * The credits being rewarded
@@ -77,13 +100,21 @@ export class Reward {
       ? data.items.map((i) => languageString(i, locale))
       : [];
 
-    this.countedItems = data.countedItems
-      ? data.countedItems.map((i) => ({
-          count: i.ItemCount,
-          type: languageString(i.ItemType, locale),
-          key: languageString(i.ItemType),
-        }))
-      : [];
+    const fromItems = (data.items ?? []).map((i) => ({
+      uniqueName: i,
+      type: languageString(i, locale),
+      key: languageString(i),
+      count: 1,
+    }));
+
+    const fromCounted = (data.countedItems ?? []).map((i) => ({
+      uniqueName: i.ItemType,
+      type: languageString(i.ItemType, locale),
+      key: languageString(i.ItemType),
+      count: i.ItemCount,
+    }));
+
+    this.countedItems = [...fromItems, ...fromCounted];
 
     this.credits = data.credits || 0;
 
@@ -100,17 +131,13 @@ export class Reward {
    * The types of all items that are being rewarded
    */
   getTypes(): string[] {
-    return this.items
-      .concat(this.countedItems.map((i) => i.key))
-      .map((t) => getItemType(t));
+    return this.countedItems.map((i) => getItemType(i.key));
   }
 
   /**
    * The types of all the items that are being rewarded
    */
   private getTypesFull(): Array<RewardType> {
-    return this.items
-      .concat(this.countedItems.map((i) => i.key))
-      .map((t) => getItemTypeFull(t));
+    return this.countedItems.map((i) => getItemTypeFull(i.key));
   }
 }

--- a/lib/models/VoidTraderSchedule.ts
+++ b/lib/models/VoidTraderSchedule.ts
@@ -16,11 +16,18 @@ export class VoidTraderSchedule {
   @IsString()
   item: string;
 
+  /**
+   * The uniqueName for the featured item
+   */
+  @IsString()
+  uniqueName: string;
+
   constructor(
     data: { Expiry: ContentTimestamp; FeaturedItem: string },
     { locale = 'en' }: Dependency = { locale: 'en' }
   ) {
     this.expiry = parseDate(data.Expiry);
     this.item = languageString(data.FeaturedItem, locale);
+    this.uniqueName = data.FeaturedItem;
   }
 }

--- a/lib/models/WorldEvent.ts
+++ b/lib/models/WorldEvent.ts
@@ -263,11 +263,25 @@ export class WorldEvent extends WorldStateObject {
   regionDrops: string[];
 
   /**
+   * Raw uniqueName paths for region drops
+   */
+  @IsArray()
+  @IsString({ each: true })
+  regionDropUniqueNames: string[];
+
+  /**
    * Archwing Drops in effect while this event is active
    */
   @IsArray()
   @IsString({ each: true })
   archwingDrops: string[];
+
+  /**
+   * Raw uniqueName paths for archwing drops
+   */
+  @IsArray()
+  @IsString({ each: true })
+  archwingDropUniqueNames: string[];
 
   /**
    * Metadata provided by DE
@@ -405,7 +419,7 @@ export class WorldEvent extends WorldStateObject {
     this.rewards = Object.keys(data)
       .filter((k) => k.includes('Reward') || k.includes('reward'))
       .map((k) => new Reward(data[k as keyof RawWorldEvent] as RawReward, opts))
-      .filter((r) => r.items.length > 0);
+      .filter((r) => r.countedItems.length > 0);
 
     this.health =
       typeof data.HealthPct !== 'undefined'
@@ -461,11 +475,13 @@ export class WorldEvent extends WorldStateObject {
 
     this.isCommunity = data.Community ?? false;
 
-    this.regionDrops = (data.RegionDrops || []).map((drop) =>
+    this.regionDropUniqueNames = data.RegionDrops || [];
+    this.regionDrops = this.regionDropUniqueNames.map((drop) =>
       languageString(drop, locale)
     );
 
-    this.archwingDrops = (data.ArchwingDrops || []).map((drop) =>
+    this.archwingDropUniqueNames = data.ArchwingDrops || [];
+    this.archwingDrops = this.archwingDropUniqueNames.map((drop) =>
       languageString(drop, locale)
     );
 

--- a/test/unit/alert.spec.ts
+++ b/test/unit/alert.spec.ts
@@ -23,5 +23,20 @@ describe('Alert', function () {
         }).to.not.throw(TypeError);
       }
     });
+
+    it('should preserve item uniqueNames on countedItems and exclusiveWeapon', () => {
+      const raw = Alerts[0];
+      const alert = new Alert(raw, { locale: 'en' });
+      const itemPath = raw.MissionInfo.missionReward.items[0];
+
+      expect(alert.mission.reward!.countedItems).to.have.length(1);
+      expect(alert.mission.reward!.countedItems[0].uniqueName).to.equal(
+        itemPath
+      );
+      expect(alert.mission.reward!.countedItems[0].count).to.equal(1);
+      expect(alert.mission.exclusiveWeaponUniqueName).to.equal(
+        raw.MissionInfo.exclusiveWeapon
+      );
+    });
   });
 });

--- a/test/unit/calendar.spec.ts
+++ b/test/unit/calendar.spec.ts
@@ -20,6 +20,9 @@ describe('SentientOutpost', function () {
       expect(calendar.days[4].events[0].reward!).to.equal(
         'Exilus Weapon Adapter Blueprint'
       );
+      expect(calendar.days[4].events[0].uniqueName).to.equal(
+        '/Lotus/StoreItems/Types/Recipes/Components/WeaponUtilityUnlockerBlueprint'
+      );
       expect(calendar.days[0].date).to.equal('1999-01-06T00:00:00.000Z');
     });
     it('should throw TypeError when called with no argument or an invalid argument', function () {

--- a/test/unit/event.spec.ts
+++ b/test/unit/event.spec.ts
@@ -21,5 +21,19 @@ describe('Event', () => {
         new WorldEvent(events[0] as unknown as RawWorldEvent);
       }).to.not.throw();
     });
+
+    it('should preserve region and archwing drop uniqueNames', () => {
+      const regionDrop =
+        '/Lotus/StoreItems/Weapons/Corpus/LongGuns/CrpBFG/Vandal/VandalCrpBFG';
+      const archwingDrop = '/Lotus/StoreItems/Upgrades/Skins/Clan/OrbBadgeItem';
+      const event = new WorldEvent({
+        ...(events[0] as unknown as RawWorldEvent),
+        RegionDrops: [regionDrop],
+        ArchwingDrops: [archwingDrop],
+      });
+
+      expect(event.regionDropUniqueNames).to.deep.equal([regionDrop]);
+      expect(event.archwingDropUniqueNames).to.deep.equal([archwingDrop]);
+    });
   });
 });

--- a/test/unit/flashsale.spec.ts
+++ b/test/unit/flashsale.spec.ts
@@ -14,5 +14,23 @@ describe('FlashSale', function () {
         new FlashSale({} as unknown as RawFlashSale);
       }).to.throw(TypeError);
     });
+
+    it('should preserve TypeName as uniqueName', function () {
+      const typeName =
+        '/Lotus/StoreItems/Upgrades/Skins/Events/InfQuantaInfestedAladV';
+      const sale = new FlashSale({
+        TypeName: typeName,
+        StartDate: { $date: { $numberLong: '1586372400000' } },
+        EndDate: { $date: { $numberLong: '1586977200000' } },
+        Discount: 50,
+        RegularOverride: 0,
+        PremiumOverride: 100,
+        ShowInMarket: true,
+        Featured: false,
+        Popular: false,
+      });
+
+      expect(sale.uniqueName).to.equal(typeName);
+    });
   });
 });

--- a/test/unit/mission.spec.ts
+++ b/test/unit/mission.spec.ts
@@ -23,5 +23,15 @@ describe('Mission', () => {
         new Mission(mockMission);
       }).to.not.throw();
     });
+
+    it('should preserve exclusiveWeapon uniqueName', () => {
+      const mission = new Mission(mockMission);
+      expect(mission.exclusiveWeaponUniqueName).to.equal(
+        mockMission.exclusiveWeapon
+      );
+      expect(mission.requiredItemUniqueNames).to.deep.equal(
+        mockMission.requiredItems ?? []
+      );
+    });
   });
 });

--- a/test/unit/reward.spec.ts
+++ b/test/unit/reward.spec.ts
@@ -17,6 +17,28 @@ describe('Reward', function () {
         new Reward({} as unknown as RawReward);
       }).to.throw(TypeError);
     });
+
+    it('should fold items into countedItems with count 1 and uniqueName', function () {
+      const itemPath =
+        '/Lotus/StoreItems/Upgrades/Skins/Events/InfQuantaInfestedAladV';
+      const countedPath = '/Lotus/StoreItems/Types/Items/MiscItems/Kuva';
+      const reward = new Reward({
+        items: [itemPath],
+        countedItems: [{ ItemType: countedPath, ItemCount: 5 }],
+        credits: 100,
+      });
+
+      expect(reward.items).to.have.length(1);
+      expect(reward.countedItems).to.have.length(2);
+      expect(reward.countedItems[0]).to.include({
+        uniqueName: itemPath,
+        count: 1,
+      });
+      expect(reward.countedItems[1]).to.include({
+        uniqueName: countedPath,
+        count: 5,
+      });
+    });
   });
   describe('getItemType', function () {
     it('should categorize the items using the provided functions', function () {

--- a/test/unit/voidtrader.spec.ts
+++ b/test/unit/voidtrader.spec.ts
@@ -25,5 +25,12 @@ describe('VoidTrader', () => {
         new VoidTrader(VaultTrader, deps);
       }).to.not.throw();
     });
+
+    it('should preserve FeaturedItem as uniqueName on schedule entries', () => {
+      const trader = new VoidTrader(VaultTrader, deps);
+      expect(trader.schedule[0].uniqueName).to.equal(
+        VaultTrader.ScheduleInfo[0].FeaturedItem
+      );
+    });
   });
 });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Preserve raw TypeName/ItemType/FeaturedItem paths and fold Reward.items into countedItems.

closes #943

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**
